### PR TITLE
Replaced vol-09c7933ad01825300 with $volume

### DIFF
--- a/modules/audit_aws_ec2.sh
+++ b/modules/audit_aws_ec2.sh
@@ -40,7 +40,7 @@ audit_aws_ec2 () {
   done
   volumes=`aws ec2 describe-volumes --query "Volumes[].VolumeId" --output text`
   for volume in $volumes; do
-    check=`aws ec2 describe-volumes --volume-id vol-09c7933ad01825300 --query "Volumes[].Encrypted" |grep true`
+    check=`aws ec2 describe-volumes --volume-id $volume --query "Volumes[].Encrypted" |grep true`
     if [ "$check" ]; then
       increment_secure "EBS Volume $volume is encrypted"
     else


### PR DESCRIPTION
`vol-09c7933ad01825300` was hard-coded in the script and the checks weren't running as proposed