### PR TITLE
Fixing typo

### DIFF
--- a/modules/audit_aws_certs.sh
+++ b/modules/audit_aws_certs.sh
@@ -10,7 +10,7 @@ audit_aws_certs () {
   cur_secs=`date -j -f "%Y-%m-%dT%H:%M:%SS" "$cur_date" "+%s"`
   for cert in $certs; do
   	exp_date=`aws iam get-server-certificate --server-certificate-name $cert --query "ServerCertificate.ServerCertificateMetadata.Expiration" --output text`
-    exp_secs=`date -j -f "%Y-%m-%dT%H:%M:%SS" "$exp_date" "+%s"`
+    exp_secs=`date -j -f "%Y-%m-%dT%H:%M:%SZ" "$exp_date" "+%s"`
     if [ "$exp_secs" -lt "$cur_secs" ]; then
       increment_insecure "Certificate $cert has expired"
     else


### PR DESCRIPTION
Was getting this 
`[shivankarmadaan@Shivankar-Madaan ~/cs-suite-1/lunar] master $date -j -f "%Y-%m-%dT%H:%M:%Z" 2016-10-17T19:08:13Z "+%s"
Failed conversion of ``2016-10-17T19:08:13Z'' using format ``%Y-%m-%dT%H:%M:%Z''
date: illegal time format
usage: date [-jnu] [-d dst] [-r seconds] [-t west] [-v[+|-]val[ymwdHMS]] ...
            [-f fmt date | [[[mm]dd]HH]MM[[cc]yy][.ss]] [+format]`
The above approach fixes it