### PR TITLE
Fix fs.suid.dumpable check

### DIFF
--- a/modules/audit_execshield.sh
+++ b/modules/audit_execshield.sh
@@ -23,7 +23,7 @@ audit_execshield () {
         # Configure kernel shield
         check_file_value is $check_file kernel.exec-shield eq 1 hash
         # Restrict core dumps
-        check_file_value is $check_file fs.suid.dumpable eq 0 has
+        check_file_value is $check_file fs.suid.dumpable eq 0 hash
       fi
     else
       if [ "$os_vendor" = "SuSE" ]; then


### PR DESCRIPTION
It looks like commit 066a29afd931cc776242b072ae2493ab61772c96 resulted in `hash` being inadvertently truncated to `has`.

I haven't tested this PR.

!["hash" truncated to "has"](https://user-images.githubusercontent.com/434827/60394303-63360e80-9b65-11e9-8b88-110eb4e810d3.png)
