### PR TITLE
Remove use of legacy backticks for command substitutions

### DIFF
--- a/modules/audit_aide.sh
+++ b/modules/audit_aide.sh
@@ -15,7 +15,7 @@ audit_aide() {
     if [ "$os_vendor" = "CentOS" ] || [ "$os_vendor" = "Red" ] || [ "$os_vendor" = "Amazon" ]; then
       check_file="/etc/sysconfig/prelink"
       if [ -f "$check_file" ]; then
-        prelink_check=`cat $check_file |grep PRELINKING |cut -f2 -d= |sed 's/ //g'`
+        prelink_check=$( grep PRELINKING $check_file | cut -f2 -d= | sed 's/ //g' )
       else
         prelink_check="no"
       fi

--- a/modules/audit_app_perms.sh
+++ b/modules/audit_app_perms.sh
@@ -9,7 +9,7 @@ audit_app_perms () {
     if [ "$audit_mode" != 2 ]; then
       OFS=$IFS
       IFS=$'\n'
-      app_dirs=`ls /Applications`
+      app_dirs=$( ls /Applications )
       for app_dir in $app_dirs; do
         check_file_perms "/Applications/$app_dir" 0755
       done

--- a/modules/audit_apparmour.sh
+++ b/modules/audit_apparmour.sh
@@ -22,7 +22,7 @@ audit_apparmour () {
         restore_file $check_file $restore_dir
       else
         if [ -f "$check_file" ]; then
-          armour_test=`cat $check_file |grep "apparmour=0" |head -1 |wc -l`
+          armour_test=$( grep "apparmour=0" $check_file | head -1 | wc -l )
         else
           armour_test=0
         fi

--- a/modules/audit_aws_access_keys.sh
+++ b/modules/audit_aws_access_keys.sh
@@ -6,16 +6,16 @@
 audit_aws_access_keys () {
   verbose_message "Access Keys"
   aws iam generate-credential-report 2>&1 > /dev/null
-  entries=`aws iam get-credential-report --query 'Content' --output text | $base64_d | cut -d, -f1,4,9,11,14,16 | sed '1 d' |grep -v '<root_account>' |awk -F '\n' '{print $1}'`
+  entries=$( aws iam get-credential-report --query 'Content' --output text | $base64_d | cut -d, -f1,4,9,11,14,16 | sed '1 d' | grep -v '<root_account>' | awk -F '\n' '{print $1}' )
   for entry in $entries; do
-    aws_user=`echo "$entry" |cut -d, -f1`
-    key1_use=`echo "$entry" |cut -d, -f3`
-    key1_last=`echo "$entry" |cut -d, -f4`
-    key2_use=`echo "$entry" |cut -d, -f5`
-    key2_last=`echo "$entry" |cut -d, -f6`
+    aws_user=$( echo "$entry" |cut -d, -f1 )
+    key1_use=$( echo "$entry" |cut -d, -f3 )
+    key1_last=$( echo "$entry" |cut -d, -f4 )
+    key2_use=$( echo "$entry" |cut -d, -f5 )
+    key2_last=$( echo "$entry" |cut -d, -f6 )
     if [ "$key1_use" = "true" ] && [ "$key1_last" = "N/A" ]; then
       increment_insecure "Account $aws_user has key access enabled but has not used their AWS API credentials consider removing keys"
-      key_ids=`aws iam list-access-keys --user-name $aws_user --query "AccessKeyMetadata[].{AccessKeyId:AccessKeyId, Status:Status}" --output text |grep Active |awk '{print $1}'`
+      key_ids=$( aws iam list-access-keys --user-name $aws_user --query "AccessKeyMetadata[].{AccessKeyId:AccessKeyId, Status:Status}" --output text | grep Active | awk '{print $1}' )
       for key_id in $key_ids; do
         lockdown_command "aws iam delete-access-key --access-key $key_id --user-name $aws_user"
       done
@@ -29,4 +29,3 @@ audit_aws_access_keys () {
     fi
   done
 }
-

--- a/modules/audit_aws_cdn.sh
+++ b/modules/audit_aws_cdn.sh
@@ -9,31 +9,31 @@
 audit_aws_cdn () {
   verbose_message "Cloudfront"
   aws configure set preview.cloudfront true
-  cdns=`aws cloudfront list-distributions --query 'DistributionList.Items[].Id' --output text |grep -v null` 
+  cdns=$( aws cloudfront list-distributions --query 'DistributionList.Items[].Id' --output text | grep -v null )
   for cdn in $cdns; do 
     # Check Cloudfront is using WAF
-    check=`aws cloudfront get-distribution --id $cdn --query 'Distribution.DistributionConfig.WebACLId' --output text`
+    check=$( aws cloudfront get-distribution --id $cdn --query 'Distribution.DistributionConfig.WebACLId' --output text )
     if [ "$check" ]; then
       increment_secure "Cloudfront $cdn is WAF integration enabled"
     else
       increment_insecure "Cloudfront $cdn is not WAF integration enabled"
     fi
     # Check logging is enabled
-    check=`aws cloudfront get-distribution --id $cdn --query 'Distribution.DistributionConfig.Logging.Enabled' | grep true`
+    check=$( aws cloudfront get-distribution --id $cdn --query 'Distribution.DistributionConfig.Logging.Enabled' | grep true )
     if [ "$check" ]; then
       increment_secure "Cloudfront $cdn has logging enabled"
     else
       increment_insecure "Cloudfront $cdn does not have logging enabled"
     fi
     # check SSL protocol versions being used against deprecated ones
-    check=`aws cloudfront get-distribution --id $cdn --query 'Distribution.DistributionConfig.Origins.Items[].CustomOriginConfig.OriginSslProtocols.Items' |egrep "SSLv3|SSLv2"`
+    check=$( aws cloudfront get-distribution --id $cdn --query 'Distribution.DistributionConfig.Origins.Items[].CustomOriginConfig.OriginSslProtocols.Items' | egrep "SSLv3|SSLv2" )
     if [ ! "$check" ]; then
       increment_secure "Cloudfront $cdn is not using a deprecated version of SSL"
     else
       increment_insecure "Cloudfront $cdn is using a deprecated verions of SSL"
     fi
     # check if HTTP only being used 
-    check=`aws cloudfront get-distribution --id $cdn --query 'Distribution.DistributionConfig.Origins.Items[].CustomOriginConfig.OriginProtocolPolicy' |egrep "http-only"`
+    check=$( aws cloudfront get-distribution --id $cdn --query 'Distribution.DistributionConfig.Origins.Items[].CustomOriginConfig.OriginProtocolPolicy' | egrep "http-only" )
     if [ ! "$check" ]; then
       increment_secure "Cloudfront $cdn is not using HTTP only"
     else

--- a/modules/audit_aws_certs.sh
+++ b/modules/audit_aws_certs.sh
@@ -5,19 +5,19 @@
 
 audit_aws_certs () {
   verbose_message "Certificates"
-  certs=`aws iam list-server-certificates --region $aws_region --query "ServerCertificateMetadataList[].ServerCertificateName" --output text`
-  cur_date=`date "+%Y-%m-%dT%H:%M:%SS"`
+  certs=$( aws iam list-server-certificates --region $aws_region --query "ServerCertificateMetadataList[].ServerCertificateName" --output text )
+  cur_date=$( date "+%Y-%m-%dT%H:%M:%SS" )
   if [ "$os_name" = "Linux" ]; then
-    cur_secs=`date -d "$cur_date" "+%s"`
+    cur_secs=$( date -d "$cur_date" "+%s" )
   else
-    cur_secs=`date -j -f "%Y-%m-%dT%H:%M:%SS" "$cur_date" "+%s"`
+    cur_secs=$( date -j -f "%Y-%m-%dT%H:%M:%SS" "$cur_date" "+%s" )
   fi
   for cert in $certs; do
-  	exp_date=`aws iam get-server-certificate --server-certificate-name $cert --query "ServerCertificate.ServerCertificateMetadata.Expiration" --output text`
+  	exp_date=$( aws iam get-server-certificate --server-certificate-name $cert --query "ServerCertificate.ServerCertificateMetadata.Expiration" --output text )
     if [ "$os_name" = "Linux" ]; then
-      exp_secs=`date -d "$exp_date" "+%s"`
+      exp_secs=$( date -d "$exp_date" "+%s" )
     else
-      exp_secs=`date -j -f "%Y-%m-%dT%H:%M:%SZ" "$exp_date" "+%s"`
+      exp_secs=$( date -j -f "%Y-%m-%dT%H:%M:%SZ" "$exp_date" "+%s" )
     fi
     if [ "$exp_secs" -lt "$cur_secs" ]; then
       increment_insecure "Certificate $cert has expired"

--- a/modules/audit_aws_cf.sh
+++ b/modules/audit_aws_cf.sh
@@ -7,10 +7,10 @@
 audit_aws_cf () {
   # Check Cloud Formation stacks are using SNS
   verbose_message "CloudFormation"
-  stacks=`aws cloudformation list-stacks --region $aws_region --query 'StackSummaries[].StackId' --output text` 
+  stacks=$( aws cloudformation list-stacks --region $aws_region --query 'StackSummaries[].StackId' --output text )
   for stack in $stacks; do 
-    check=`aws cloudformation describe-stacks --region $aws_region --stack-name $stack --query 'Stack[].NotificationARNs' --output text`
-    stack=`echo "$stack" |cut -f2 -d/`
+    check=$( aws cloudformation describe-stacks --region $aws_region --stack-name $stack --query 'Stack[].NotificationARNs' --output text )
+    stack=$( echo "$stack" | cut -f2 -d/ )
     if [ "$check" ]; then
       increment_secure "SNS topic exists for CloudFormation stack $stack"
     else
@@ -18,9 +18,9 @@ audit_aws_cf () {
     fi
   done
   # Check stacks have a policy
-  stacks=`aws cloudformation list-stacks --region $aws_region --query 'StackSummaries[].StackName' --output text`
+  stacks=$( aws cloudformation list-stacks --region $aws_region --query 'StackSummaries[].StackName' --output text )
     for stack in $stacks; do 
-    check=`aws cloudformation get-stack-policy --region $aws_region --stack-name $stack --query 'StackPolicyBody' --output text 2> /dev/null`
+    check=$( aws cloudformation get-stack-policy --region $aws_region --stack-name $stack --query 'StackPolicyBody' --output text 2> /dev/null )
     if [ "$check" ]; then
       increment_secure "CloudFormation stack $stack has a policy"
     else

--- a/modules/audit_aws_config.sh
+++ b/modules/audit_aws_config.sh
@@ -5,14 +5,14 @@
 
 audit_aws_config () {
   verbose_message "Config"
-	check=`aws configservice describe-configuration-recorders --region $aws_region`
+	check=$( aws configservice describe-configuration-recorders --region $aws_region )
   if [ ! "$check" ]; then
     increment_insecure "AWS Configuration Recorder not enabled"
     lockdown_command "aws configservice start-configuration-recorder" fix
   else
     increment_secure "AWS Configuration Recorder enabled"
   fi
-  check=`aws configservice --region $aws_region get-status |grep FAILED`
+  check=$( aws configservice --region $aws_region get-status | grep FAILED )
   if [ "$check" ]; then
     increment_insecure "AWS Config not enabled"
   else

--- a/modules/audit_aws_creds.sh
+++ b/modules/audit_aws_creds.sh
@@ -8,19 +8,19 @@
 audit_aws_creds () {
   verbose_message "Credentials"
   aws iam generate-credential-report 2>&1 > /dev/null
-  entries=`aws iam get-credential-report --query 'Content' --output text | $base64_d | cut -d, -f1,4,5,6,9,10,11,14,15,16 | sed '1 d' |awk -F '\n' '{print $1}'`
+  entries=$( aws iam get-credential-report --query 'Content' --output text | $base64_d | cut -d, -f1,4,5,6,9,10,11,14,15,16 | sed '1 d' | awk -F '\n' '{print $1}' )
   for entry in $entries; do
-    aws_user=`echo "$entry" |cut -d, -f1`
-    aws_pass=`echo "$entry" |cut -d, -f2`
-    aws_last=`echo "$entry" |cut -d, -f3`
-    aws_rot=`echo "$entry" |cut -d, -f4`
-    key1_use=`echo "$entry" |cut -d, -f5`
-    key1_rot=`echo "$entry" |cut -d, -f6`
-    key1_last=`echo "$entry" |cut -d, -f7`
-    key2_use=`echo "$entry" |cut -d, -f8`
-    key2_rot=`echo "$entry" |cut -d, -f9`
-    key2_last=`echo "$entry" |cut -d, -f10`
-    curr_sec=`date "+%s"`
+    aws_user=$( echo "$entry" | cut -d, -f1 )
+    aws_pass=$( echo "$entry" | cut -d, -f2 )
+    aws_last=$( echo "$entry" | cut -d, -f3 )
+    aws_rot=$( echo "$entry" | cut -d, -f4 )
+    key1_use=$( echo "$entry" | cut -d, -f5 )
+    key1_rot=$( echo "$entry" | cut -d, -f6 )
+    key1_last=$( echo "$entry" | cut -d, -f7 )
+    key2_use=$( echo "$entry" | cut -d, -f8 )
+    key2_rot=$( echo "$entry" | cut -d, -f9 )
+    key2_last=$( echo "$entry" | cut -d, -f10 )
+    cur_sec=$( date "+%s" )
     if [ "$aws_user" = "<root_account>" ]; then
       if [ "$key1_use" = "true" ] || [ "$key2_use" = "true" ]; then
         increment_insecure "Account $aws_user is using access keys"
@@ -32,26 +32,26 @@ audit_aws_creds () {
           increment_insecure "Account $aws_user does not use any AWS credentials consider removing account"
       else
         if [ "$aws_pass" = "true" ]; then 
-          if [ "`echo $aws_last |grep '[0-9]'`" ]; then
+          if [ "$( echo $aws_last |grep '[0-9]' )" ]; then
             if [ "$os_name" = "Linux" ]; then
-              aws_sec=`date -d "$aws_last" "+%s"`
+              aws_sec=$( date -d "$aws_last" "+%s" )
             else
-              aws_sec=`date -j -f "%Y-%m-%dT%H:%M:%S+00:00" "$aws_last" "+%s"`
+              aws_sec=$( date -j -f "%Y-%m-%dT%H:%M:%S+00:00" "$aws_last" "+%s" )
             fi
-            aws_days=`echo "($curr_sec - $aws_sec)/84600" |bc`
+            aws_days=$( echo "($cur_sec - $aws_sec)/84600" | bc )
             if [ $aws_days -gt 90 ]; then
               increment_insecure "Account $aws_user has not used AWS Console credentials in over 90 days consider locking access"
             else
               increment_secure "Account $aws_user has used AWS Console credentials in the past 90 days"
             fi
           fi
-          if [ "`echo "$aws_rot" |grep '[0-9]'`" ]; then
+          if [ "$( echo "$aws_rot" |grep '[0-9]' )" ]; then
             if [ "$os_name" = "Linux" ]; then
-              rot_sec=`date -d "$aws_last" "+%s"`
+              rot_sec=$( date -d "$aws_last" "+%s" )
             else
-              rot_sec=`date -j -f "%Y-%m-%dT%H:%M:%S+00:00" "$aws_last" "+%s"`
+              rot_sec=$( date -j -f "%Y-%m-%dT%H:%M:%S+00:00" "$aws_last" "+%s" )
             fi
-            rot_days=`echo "($rot_sec - $cur_sec)/84600" |bc`
+            rot_days=$( echo "($rot_sec - $cur_sec)/84600" | bc )
             if [ $rot_days -gt 90 ]; then
               increment_insecure "Account $aws_user will not rotate their AWS Console password in the next 90 days consider locking access"
             else
@@ -63,23 +63,23 @@ audit_aws_creds () {
         fi
         if [ "$key1_use" = "true" ]; then
           if [ "$os_name" = "Linux" ]; then
-            key1_sec=`date -d "$key1_last" "+%s"`
+            key1_sec=$( date -d "$key1_last" "+%s" )
           else
-            key1_sec=`date -j -f "%Y-%m-%dT%H:%M:%S+00:00" "$key1_last" "+%s"`
+            key1_sec=$( date -j -f "%Y-%m-%dT%H:%M:%S+00:00" "$key1_last" "+%s" )
           fi
-          key1_days=`echo "($curr_sec - $key1_sec)/84600" |bc`
+          key1_days=$( echo "($cur_sec - $key1_sec)/84600" | bc )
           if [ $key1_days -gt 90 ]; then
             increment_insecure "Account $aws_user has not used AWS API credentials in over 90 days consider removing keys"
           else
             increment_secure "Account $aws_user has used AWS API credentials in the past 90 days"
           fi
-          if [ "`echo "$key1_rot" |grep '[0-9]'`" ]; then
+          if [ "$( echo "$key1_rot" |grep '[0-9]' )" ]; then
             if [ "$os_name" = "Linux" ]; then
-              rot_sec=`date -d "$key1_rot" "+%s"`
+              rot_sec=$( date -d "$key1_rot" "+%s" )
             else
-              rot_sec=`date -j -f "%Y-%m-%dT%H:%M:%S+00:00" "$key1_rot" "+%s"`
+              rot_sec=$( date -j -f "%Y-%m-%dT%H:%M:%S+00:00" "$key1_rot" "+%s" )
             fi
-            rot_days=`echo "($curr_sec - $rot_sec)/84600" |bc`
+            rot_days=$( echo "($cur_sec - $rot_sec)/84600" | bc )
             if [ $rot_days -gt 90 ]; then
               increment_insecure "Account $aws_user will not rotate their AWS API credentials in the next 90 days"
             else
@@ -91,23 +91,23 @@ audit_aws_creds () {
         fi
         if [ "$key2_use" = "true" ]; then
           if [ "$os_name" = "Linux" ]; then
-            key2_sec=`date -d "$key2_last" "+%s"`
+            key2_sec=$( date -d "$key2_last" "+%s" )
           else
-            key2_sec=`date -j -f "%Y-%m-%dT%H:%M:%S+00:00" "$key2_last" "+%s"`
+            key2_sec=$( date -j -f "%Y-%m-%dT%H:%M:%S+00:00" "$key2_last" "+%s" )
           fi
-          key2_days=`echo "($curr_sec - $key2_sec)/84600" |bc`
+          key2_days=$( echo "($cur_sec - $key2_sec)/84600" | bc )
           if [ $key2_days -gt 90 ]; then
             increment_insecure "Account $aws_user has not used AWS SOA credentials in over 90 days consider removing keys"
           else
             increment_secure "Account $aws_user has used AWS SOA credentials in the past 90 days"
           fi
-          if [ "`echo $key2_rot |grep '[0-9]'`" ]; then
+          if [ "$( echo $key2_rot |grep '[0-9]' )" ]; then
             if [ "$os_name" = "Linux" ]; then
-              rot_sec=`date -d "$key2_rot" "+%s"`
+              rot_sec=$( date -d "$key2_rot" "+%s" )
             else
-              rot_sec=`date -j -f "%Y-%m-%dT%H:%M:%S+00:00" "$key2_rot" "+%s"`
+              rot_sec=$( date -j -f "%Y-%m-%dT%H:%M:%S+00:00" "$key2_rot" "+%s" )
             fi
-            rot_days=`echo "($curr_sec - $rot_sec)/84600" |bc`
+            rot_days=$( echo "($cur_sec - $rot_sec)/84600" | bc )
             if [ $rot_days -gt 90 ]; then
               increment_insecure "Account $aws_user will not rotate their AWS SOA credentials in the next 90 days"
             else

--- a/modules/audit_aws_dns.sh
+++ b/modules/audit_aws_dns.sh
@@ -8,32 +8,32 @@
 
 audit_aws_dns () {
   verbose_message "Route53"
-  domains=`aws route53domains list-domains --query 'Domains[].DomainName' --output text 2> /dev/null`
+  domains=$( aws route53domains list-domains --query 'Domains[].DomainName' --output text 2> /dev/null )
   for domain in $domains; do
-    check=`aws route53domains get-domain-detail --domain-name $domain |grep true`
+    check=$( aws route53domains get-domain-detail --domain-name $domain | grep true )
     if [ ! "$check" ]; then
       increment_insecure "Domain $domain does not auto renew"
       lockdown_command "aws route53domains enable-domain-auto-renew --domain-name $domain"
     else
       increment_secure "Domain $domain auto renews"
     fi
-    cur_secs=`date "+%s"`
-    exp_secs=`aws route53domains get-domain-detail --domain-name $domain --query "ExpirationDate" --output text 2> /dev/null`
+    cur_secs=$( date "+%s" )
+    exp_secs=$( aws route53domains get-domain-detail --domain-name $domain --query "ExpirationDate" --output text 2> /dev/null )
     if [ "$exp_secs" -lt "$cur_secs" ]; then
       increment_insecure "Warning:   Domain $domain registration has expired" 
     else
       increment_secure "Domain $domain registration has not expired"
     fi
-    check=`aws route53domains get-domain-detail --domain-name $domain --query "Status" --output text 2> /dev/null | grep clientTransferProhibited`
+    check=$( aws route53domains get-domain-detail --domain-name $domain --query "Status" --output text 2> /dev/null | grep clientTransferProhibited )
     if [ "$check" ]; then
       increment_secure "Domain $domain has Domain Transfer Lock enabled"
     else
       increment_insecure "Domain $domain does not have Domain Transfer Lock enabled" 
     fi
   done
-  zones=`aws route53 list-hosted-zones --query "HostedZones[].Id" --output text 2> /dev/null |cut -f3 -d'/'`
+  zones=$( aws route53 list-hosted-zones --query "HostedZones[].Id" --output text 2> /dev/null | cut -f3 -d'/' )
   for zone in $zones; do
-    spf=`aws route53 list-resource-record-sets --hosted-zone-id $zone --query "ResourceRecordSets[?Type == 'SPF']" --output text`
+    spf=$( aws route53 list-resource-record-sets --hosted-zone-id $zone --query "ResourceRecordSets[?Type == 'SPF']" --output text )
     if [ "$spf" ]; then
       increment_secure "Zone $zone has SPF records"
     else

--- a/modules/audit_aws_ec.sh
+++ b/modules/audit_aws_ec.sh
@@ -5,9 +5,9 @@
 
 audit_aws_ec () {
   verbose_message "ElastiCache"
-  caches=`aws elasticache describe-replication-groups --region $aws_region --query 'ReplicationGroups[].ReplicationGroupId' --output text` 
+  caches=$( aws elasticache describe-replication-groups --region $aws_region --query 'ReplicationGroups[].ReplicationGroupId' --output text )
   for cache in $caches; do 
-    check=`aws elasticache describe-replication-groups --region $aws_region --replication-group-id $cache --query 'ReplicationGroups[].AutomaticFailover' |grep enabled`
+    check=$( aws elasticache describe-replication-groups --region $aws_region --replication-group-id $cache --query 'ReplicationGroups[].AutomaticFailover' | grep enabled )
     if [ "$check" ]; then
       increment_secure "ElastiCache $cache is Multi-AZ enabled"
     else

--- a/modules/audit_aws_ec2.sh
+++ b/modules/audit_aws_ec2.sh
@@ -9,7 +9,7 @@
 
 audit_aws_ec2 () {
   verbose_message "EC2"
-  instances=`aws ec2 describe-instances --region $aws_region --query 'Reservations[].Instances[].InstanceId' --filters "Name=instance.group-name,Values=default" --output text`
+  instances=$( aws ec2 describe-instances --region $aws_region --query 'Reservations[].Instances[].InstanceId' --filters "Name=instance.group-name,Values=default" --output text )
   if [ ! "$instances" ]; then
     increment_secure "There are no instances using the default security group"
   else
@@ -17,18 +17,18 @@ audit_aws_ec2 () {
       increment_insecure "The instance $instance is using the default security group"
     done
   fi
-  instances=`aws ec2 describe-instances --region $aws_region --query "Reservations[].Instances[].InstanceId" --output text`
+  instances=$( aws ec2 describe-instances --region $aws_region --query "Reservations[].Instances[].InstanceId" --output text )
   for instance in $instances; do
-    profile=`aws ec2 describe-instances --region $aws_region --instance-ids $instance --query "Reservations[*].Instances[*].IamInstanceProfile" --output text`
+    profile=$( aws ec2 describe-instances --region $aws_region --instance-ids $instance --query "Reservations[*].Instances[*].IamInstanceProfile" --output text )
     if [ "$profile" ]; then
       increment_secure "Instances $instance uses an IAM profile"
     else
       increment_insecure "Warning:   Instance $instance does not use an IAM profile"
     fi
   done
-  images=`aws ec2 describe-images --region $aws_region --owners self --query "Images[].ImageId" --output text`
+  images=$( aws ec2 describe-images --region $aws_region --owners self --query "Images[].ImageId" --output text )
   for image in $images; do
-    public=`aws ec2 describe-images --owners self --region $aws_region --image-ids $image --query "Images[].Public" |grep true`
+    public=$( aws ec2 describe-images --owners self --region $aws_region --image-ids $image --query "Images[].Public" | grep true )
     if [ ! "$public" ]; then
       increment_secure "Image $image is not publicly shared"
     else
@@ -38,16 +38,16 @@ audit_aws_ec2 () {
       verbose_message "fix" 
     fi
   done
-  volumes=`aws ec2 describe-volumes --query "Volumes[].VolumeId" --output text`
+  volumes=$( aws ec2 describe-volumes --query "Volumes[].VolumeId" --output text )
   for volume in $volumes; do
-    check=`aws ec2 describe-volumes --volume-id $volume --query "Volumes[].Encrypted" |grep true`
+    check=$( aws ec2 describe-volumes --volume-id $volume --query "Volumes[].Encrypted" | grep true )
     if [ "$check" ]; then
       increment_secure "EBS Volume $volume is encrypted"
     else
       increment_insecure "EBS Volume $volume is not encrypted"
     fi
     # Check if KMS is being used
-    key_id=`aws ec2 describe-volumes --region $aws_region --volume-ids $volume --query 'Volumes[].KmsKeyId' --output text |cut -f2 -d/`
+    key_id=$( aws ec2 describe-volumes --region $aws_region --volume-ids $volume --query 'Volumes[].KmsKeyId' --output text | cut -f2 -d/ )
     if [ "$key_id" ]; then
       increment_secure "EBS Volume $volume is encrypted with a KMS key"
     else

--- a/modules/audit_aws_elb.sh
+++ b/modules/audit_aws_elb.sh
@@ -11,9 +11,9 @@
 audit_aws_elb () {
   # Ensure ELBs have logging enabled
   verbose_message "ELB"
-  elbs=`aws elb describe-load-balancers --region $aws_region --query "LoadBalancerDescriptions[].LoadBalancerName" --output text`
+  elbs=$( aws elb describe-load-balancers --region $aws_region --query "LoadBalancerDescriptions[].LoadBalancerName" --output text )
   for elb in $elbs; do
-    check=`aws elb describe-load-balancers --region $aws_region --load-balancer-name $elb  --query "LoadBalancerDescriptions[].AccessLog" |grep true`
+    check=$( aws elb describe-load-balancers --region $aws_region --load-balancer-name $elb  --query "LoadBalancerDescriptions[].AccessLog" | grep true )
     if [ ! "$check" ]; then
       increment_insecure "ELB $elb does not have access logging enabled"
       verbose_message "" fix
@@ -23,25 +23,25 @@ audit_aws_elb () {
       increment_secure "ELB $elb has access logging enabled"
     fi
     # Ensure ELBs are not using HTTP
-    protocol=`aws elb describe-load-balancers --region $aws_region --load-balancer-name $elb  --query "LoadBalancerDescriptions[].ListenerDescriptions[].Listener[].Protcol" --output text`
+    protocol=$( aws elb describe-load-balancers --region $aws_region --load-balancer-name $elb  --query "LoadBalancerDescriptions[].ListenerDescriptions[].Listener[].Protcol" --output text )
     if [ "$protocol" = "HTTP" ]; then
       increment_insecure "ELB $elb is using HTTP"
     else
       increment_secure "ELB $elb is not using HTTP"
     fi
     # Ensure ELB SGs do not have port 80 open to the world
-    sgs=`aws elb describe-load-balancers --region $aws_region --load-balancer-name $elb  --query "LoadBalancerDescriptions[].SecurityGroups" --output text`
+    sgs=$( aws elb describe-load-balancers --region $aws_region --load-balancer-name $elb  --query "LoadBalancerDescriptions[].SecurityGroups" --output text )
     for sg in $sgs; do
       check_aws_open_port $sg 80 tcp HTTP ELB $elb
     done
     # Ensure no deprecated ciphers of protocols are being used
-    list=`aws elb describe-load-balancer-policies --region $aws_region --load-balancer-name $elb --output text`
+    list=$( aws elb describe-load-balancer-policies --region $aws_region --load-balancer-name $elb --output text )
     for cipher in SSLv2 RC2-CBC-MD5 PSK-AES256-CBC-SHA PSK-3DES-EDE-CBC-SHA KRB5-DES-CBC3-SHA KRB5-DES-CBC3-MD5 \
                   PSK-AES128-CBC-SHA PSK-RC4-SHA KRB5-RC4-SHA KRB5-RC4-MD5 KRB5-DES-CBC-SHA KRB5-DES-CBC-MD5 \
                   EXP-EDH-RSA-DES-CBC-SHA EXP-EDH-DSS-DES-CBC-SHA EXP-ADH-DES-CBC-SHA EXP-DES-CBC-SHA \
                   SSLv3 EXP-RC2-CBC-MD5 EXP-KRB5-RC2-CBC-SHA EXP-KRB5-DES-CBC-SHA EXP-KRB5-RC2-CBC-MD5 \
                   EXP-KRB5-DES-CBC-MD5 EXP-ADH-RC4-MD5 EXP-RC4-MD5 EXP-KRB5-RC4-SHA EXP-KRB5-RC4-MD5; do
-      check=`echo "$list" |grep $cipher |grep true`
+      check=$( echo "$list" | grep $cipher | grep true )
       if [ "$check" ]; then
         increment_insecure "ELB $elb is using deprecated cipher $cipher"
       else

--- a/modules/audit_aws_es.sh
+++ b/modules/audit_aws_es.sh
@@ -6,15 +6,15 @@
 
 audit_aws_es () {
   verbose_message "Elasticsearch"
-  domains=`aws es list-domain-names --region $aws_region --query "DomainNames[].DomainName" --output text`
+  domains=$( aws es list-domain-names --region $aws_region --query "DomainNames[].DomainName" --output text )
   for domain in $domains; do
-    check=`aws es describe-elasticsearch-domain --domain-name $domain --query 'DomainStatus.AccessPolicies' --output text |grep Principle | grep "{\"AWS\":\"\*\"}"`
+    check=$( aws es describe-elasticsearch-domain --domain-name $domain --query 'DomainStatus.AccessPolicies' --output text | grep Principle | grep "{\"AWS\":\"\*\"}" )
     if [ ! "$check" ]; then
       increment_secure "Elasticsearch domain $domain is not publicly accessible"
     else
       increment_insecure "Elasticsearch domain $domain is publicly accessible"
     fi
-    check=`aws es describe-elasticsearch-domain --domain-name $domain --query 'DomainStatus.AccessPolicies' --output text |grep "aws:SourceIp" |grep "[0-9]\."`
+    check=$( aws es describe-elasticsearch-domain --domain-name $domain --query 'DomainStatus.AccessPolicies' --output text | grep "aws:SourceIp" | grep "[0-9]\." )
     if [ "$check" ]; then
       increment_secure "Elasticsearch doamin $domain has an IP based access policy"
     else

--- a/modules/audit_aws_iam.sh
+++ b/modules/audit_aws_iam.sh
@@ -12,15 +12,15 @@ audit_aws_iam () {
   # Root account should only be used sparingly, admin functions and responsibilities should be delegated
   verbose_message "IAM"
   aws iam generate-credential-report 2>&1 > /dev/null
-  date_test=`date +%Y-%m`
-  last_login=`aws iam get-credential-report --query 'Content' --output text | $base64_d | cut -d, -f1,5,11,16 | grep -B1 '<root_account>' |cut -f2 -d, |cut -f1,2 -d- |grep '[0-9]'`
+  date_test=$( date +%Y-%m )
+  last_login=$( aws iam get-credential-report --query 'Content' --output text | $base64_d | cut -d, -f1,5,11,16 | grep -B1 '<root_account>' | cut -f2 -d, | cut -f1,2 -d- | grep '[0-9]' )
   if [ "$date_test" = "$last_login" ]; then
     increment_insecure "Root account appears to be being used regularly"
   else
     increment_secure "Root account does not appear to be being used frequently"
   fi
   # Check to see if there is an IAM master role
-  check=`aws iam get-role --role-name $aws_iam_master_role 2> /dev/null`
+  check=$( aws iam get-role --role-name $aws_iam_master_role 2> /dev/null )
   if [ "$check" ]; then 
     increment_secure "IAM Master role $aws_iam_master_role exists"
   else
@@ -32,7 +32,7 @@ audit_aws_iam () {
     verbose_message "" fix
   fi
   # Check there is an IAM manager role
-  check=`aws iam get-role --role-name $aws_iam_manager_role 2> /dev/null`
+  check=$( aws iam get-role --role-name $aws_iam_manager_role 2> /dev/null )
   if [ "$check" ]; then 
     increment_secure "IAM Manager role $aws_iam_manager_role exists"
   else
@@ -44,19 +44,19 @@ audit_aws_iam () {
     verbose_message "" fix
   fi
   # Check groups have members
-  groups=`aws iam list-groups --query 'Groups[].GroupName' --output text`
+  groups=$( aws iam list-groups --query 'Groups[].GroupName' --output text )
   for group in $groups; do
-    users=`aws iam get-group --group-name $group --query "Users" --output text`
+    users=$( aws iam get-group --group-name $group --query "Users" --output text )
     if [ "$users" ]; then
       increment_secure "IAM group $group is not empty"
     else
       increment_insecure "IAM group $group is empty"
     fi
   done
-  users=`aws iam list-users --query 'Users[].UserName' --output text`
+  users=$( aws iam list-users --query 'Users[].UserName' --output text )
   for user in $users; do
     # Check for inactive users
-    check=`aws iam list-access-keys --user-name $user --query "AccessKeyMetadata" --output text`
+    check=$( aws iam list-access-keys --user-name $user --query "AccessKeyMetadata" --output text )
     if [ "$check" ]; then
       increment_secure "IAM user $user is active"
     else
@@ -66,7 +66,7 @@ audit_aws_iam () {
       verbose_message "" fix
     fi
     # Check users do not have attached policies, they should be members of groups which have those policies
-    policies=`aws iam list-attached-user-policies --user-name $user --query "AttachedPolicies[].PolicyArn" --output text`
+    policies=$( aws iam list-attached-user-policies --user-name $user --query "AttachedPolicies[].PolicyArn" --output text )
     if [ "$policies" ]; then
       for policy in $policies; do
         increment_insecure "IAM user $user has attached policy $policy"

--- a/modules/audit_aws_inspector.sh
+++ b/modules/audit_aws_inspector.sh
@@ -6,21 +6,21 @@
 audit_aws_inspector () {
   # check for templates
   verbose_message "Inspector"
-  templates=`aws inspector list-assessment-templates 2> /dev/null --output text`
+  templates=$( aws inspector list-assessment-templates 2> /dev/null --output text )
   if [ "$templates" ]; then
     # check for subscriptions to templates
-    check=`aws inspector list-event-subscriptions --region $aws_region --query subscriptions --output text`
+    check=$( aws inspector list-event-subscriptions --region $aws_region --query subscriptions --output text )
     if [ "$check" ]; then
       increment_secure "Inspectors have subscriptions"
     else
       increment_insecure "Inspectors do not have subscriptions"
     fi
     for template in $templates; do
-      names=`aws inspector describe-assessment-templates --region $aws_region --assessment-template-arns $template --query 'assessmentTemplates[].name' --output text`
+      names=$( aws inspector describe-assessment-templates --region $aws_region --assessment-template-arns $template --query 'assessmentTemplates[].name' --output text )
       for name in $names; do
-        instances=`aws ec2 describe-instances --region $aws_region --query 'Reservations[].Instances[].InstanceId' --output text`
+        instances=$( aws ec2 describe-instances --region $aws_region --query 'Reservations[].Instances[].InstanceId' --output text )
         for instance in $instances; do
-          check=`aws ec2 describe-instances --region $aws_region --instance-id $instance --query 'Reservations[].Instances[].Tags' |grep $name`
+          check=$( aws ec2 describe-instances --region $aws_region --instance-id $instance --query 'Reservations[].Instances[].Tags' | grep $name )
           if [ "$check" ]; then
             increment_secure "Instance $instance has an inspector tag"
           else

--- a/modules/audit_aws_keys.sh
+++ b/modules/audit_aws_keys.sh
@@ -8,11 +8,11 @@
 
 audit_aws_keys () {
   verbose_message "KMS Keys"
-  keys=`aws kms list-keys --query Keys --output text`
+  keys=$( aws kms list-keys --query Keys --output text )
   if [ "$keys" ]; then
     for key in $keys; do
       # Check key is enabled
-      check=`aws kms get-key-rotation-status --key-id $key --query 'KeyMetadata' |grep Enabled |grep true`
+      check=$( aws kms get-key-rotation-status --key-id $key --query 'KeyMetadata' | grep Enabled | grep true )
       if [ ! "$check" ]; then
         increment_insecure "Key $key is not enabled"
         verbose_message "" fix
@@ -22,7 +22,7 @@ audit_aws_keys () {
         increment_secure "Key $key is enabled"
       fi
       # Check that key rotation is enabled
-      check=`aws kms get-key-rotation-status --key-id $key |grep KeyRotationEnabled |grep true`
+      check=$( aws kms get-key-rotation-status --key-id $key |grep KeyRotationEnabled | grep true )
       if [ ! "$check" ]; then
         increment_insecure "Key $key does not have key rotation enabled"
         verbose_message "" fix
@@ -37,9 +37,9 @@ audit_aws_keys () {
     increment_insecure "No Keys are being used"
   fi
   # Check for SSH keys
-  users=`aws iam list-users --query 'Users[].UserName' --output text`
+  users=$( aws iam list-users --query 'Users[].UserName' --output text )
   for user in $users; do
-    check=`aws iam list-ssh-public-keys --region $aws_region --user-name $user |grep Active |wc -l`
+    check=$( aws iam list-ssh-public-keys --region $aws_region --user-name $user | grep Active | wc -l )
     if [ "$check" -gt 1 ]; then
       increment_insecure "User $user does has more than one active SSH key"
     else

--- a/modules/audit_aws_mfa.sh
+++ b/modules/audit_aws_mfa.sh
@@ -10,11 +10,11 @@
 
 audit_aws_mfa () {
   verbose_message "MFA"
-  entries=`aws iam get-credential-report --query 'Content' --output text | $base64_d | cut -d, -f1,4,8 | sed '1 d' |awk -F '\n' '{print $1}'`
+  entries=$( aws iam get-credential-report --query 'Content' --output text | $base64_d | cut -d, -f1,4,8 | sed '1 d' | awk -F '\n' '{print $1}' )
   for entry in $entries; do
-    user=`echo "$entry" |cut -d, -f1`
-    pass=`echo "$entry" |cut -d, -f2`
-    mfa=`echo "$entry" |cut -d, -f3`
+    user=$( echo "$entry" | cut -d, -f1 )
+    pass=$( echo "$entry" | cut -d, -f2 )
+    mfa=$( echo "$entry" | cut -d, -f3 )
     if [ "$user" = "<root_account>" ]; then
       if [ "$mfa" = "false" ]; then
         increment_insecure "Account $user does not have MFA enabled"
@@ -33,10 +33,10 @@ audit_aws_mfa () {
       fi
     fi
   done
-  mfa_check=`aws iam get-account-summary | grep "AccountMFAEnabled" |cut -f1 -d: |sed "s/ //g" |sed "s/,//g"`
+  mfa_check=$( aws iam get-account-summary | grep "AccountMFAEnabled" | cut -f1 -d: | sed "s/ //g" | sed "s/,//g" )
   if [ "$mfa_check" = "1" ]; then
     increment_secure "The root account has MFA enabled"
-    mfa_check=`iaws iam list-virtual-mfa-devices |grep "SerialNumber" |grep "root_account" |wc -l`
+    mfa_check=$( iaws iam list-virtual-mfa-devices | grep "SerialNumber" | grep "root_account" | wc -l )
     if [ "$mfa_check" = "0" ]; then
       increment_secure "The root account does not have a virtual MFA"
     else
@@ -47,4 +47,3 @@ audit_aws_mfa () {
     increment_insecure "The root account does not a hardware MFA"
   fi
 }
-

--- a/modules/audit_aws_monitoring.sh
+++ b/modules/audit_aws_monitoring.sh
@@ -32,11 +32,11 @@
 
 audit_aws_monitoring () {
   verbose_message "CloudWatch"
-  trails=`aws cloudtrail describe-trails --region $aws_region --query "trailList[].CloudWatchLogsLogGroupArn" --output text |awk -F':' '{print $7}'`
+  trails=$( aws cloudtrail describe-trails --region $aws_region --query "trailList[].CloudWatchLogsLogGroupArn" --output text | awk -F':' '{print $7}' )
   if [ "$trails" ]; then
     increment_secure "CloudWatch log groups exits for CloudTrail"
     for trail in $trails; do
-      metrics=`aws logs describe-metric-filters --region $aws_region --log-group-name $trail --query "metricFilters[].filterPattern" --output text`
+      metrics=$( aws logs describe-metric-filters --region $aws_region --log-group-name $trail --query "metricFilters[].filterPattern" --output text )
       if [ ! "$metrics" ]; then
         increment_insecure "CloudWatch log group $trail has no metrics"
         verbose_message "" fix
@@ -76,7 +76,7 @@ audit_aws_monitoring () {
                       CreateVpc DeleteVpc ModifyVpcAttribute AcceptVpcPeeringConnection CreateVpcPeeringConnection DeleteVpcPeeringConnection \
                       RejectVpcPeeringConnection AttachClassicLinkVpc DetachClassicLinkVpc DisableVpcClassicLink EnableVpcClassicLink \
                       TerminateInstances StopInstances StartInstances RebootInstances RunInstances; do
-          check=`aws logs describe-metric-filters --region $aws_region --log-group-name $trail --query "metricFilters[].filterPattern" --output text |grep "$metric"`
+          check=$( aws logs describe-metric-filters --region $aws_region --log-group-name $trail --query "metricFilters[].filterPattern" --output text |grep "$metric" )
           if [ "$check" ]; then
             increment_secure "CloudWatch log group $trail metrics include $metric"
           else
@@ -88,11 +88,11 @@ audit_aws_monitoring () {
   else
     increment_insecure "No CloudWatch log groups exist for CloudTrail"
   fi
-  alarms=`aws cloudwatch describe-alarms --region $aws_region --query "MetricAlarms[].AlarmActions" --output text`
+  alarms=$( aws cloudwatch describe-alarms --region $aws_region --query "MetricAlarms[].AlarmActions" --output text )
   if [ "$alarms" ]; then
     increment_secure "CloudWatch alarms exits for CloudTrail"
     for alarm in $alarms; do
-      subscribers=`aws sns list-subscriptions-by-topic --region $aws_region --topic-arn $alarm --output text`
+      subscribers=$( aws sns list-subscriptions-by-topic --region $aws_region --topic-arn $alarm --output text )
       if [ "$subscribers" ]; then
         increment_secure "CloudWatch alarm $alarm has subscribers"
       else

--- a/modules/audit_aws_password_policy.sh
+++ b/modules/audit_aws_password_policy.sh
@@ -11,8 +11,8 @@
 
 audit_aws_password_policy () {
   verbose_message "Password Policy"
-  policy=`aws iam get-account-password-policy 2> /dev/null`
-  length=`echo "$pass_pol" |wc -l`
+  policy=$( aws iam get-account-password-policy 2> /dev/null )
+  length=$( echo "$pass_pol" | wc -l )
   if [ "$length" = "0" ]; then
     increment_insecure "No password policy exists"
     verbose_message "" fix

--- a/modules/audit_aws_rds.sh
+++ b/modules/audit_aws_rds.sh
@@ -11,10 +11,10 @@
 
 audit_aws_rds () {
   verbose_message "RDS"
-  dbs=`aws rds describe-db-instances --region $aws_region --query 'DBInstances[].DBInstanceIdentifier' --output text`
+  dbs=$( aws rds describe-db-instances --region $aws_region --query 'DBInstances[].DBInstanceIdentifier' --output text )
   for db in $dbs; do
     # Check if auto minor version upgrades are enabled
-    check=`aws rds describe-db-instances --region $aws_region --db-instance-identifier $db --query 'DBInstances[].AutoMinorVersionUpgrade' |grep true`
+    check=$( aws rds describe-db-instances --region $aws_region --db-instance-identifier $db --query 'DBInstances[].AutoMinorVersionUpgrade' | grep true )
     if [ "$check" ]; then
       increment_secure "RDS instance $db has auto minor version upgrades enabled"
     else
@@ -24,7 +24,7 @@ audit_aws_rds () {
       verbose_message "" fix
     fi
     # Check if automated backups are enabled
-    check=`aws rds describe-db-instances --region $aws_region --db-instance-identifier $db --query 'DBInstances[].BackupRetentionPeriod' --output text`
+    check=$( aws rds describe-db-instances --region $aws_region --db-instance-identifier $db --query 'DBInstances[].BackupRetentionPeriod' --output text )
     if [ ! "$check" -eq "0" ]; then
       increment_secure "RDS instance $db has automated backups enabled"
     else
@@ -34,35 +34,35 @@ audit_aws_rds () {
       verbose_message "" fix
     fi
     # Check if RDS instance is encrypted
-    check=`aws rds describe-db-instances --region $aws_region --db-instance-identifier $db --query 'DBInstances[].StorageEncrypted' |grep true`
+    check=$( aws rds describe-db-instances --region $aws_region --db-instance-identifier $db --query 'DBInstances[].StorageEncrypted' | grep true )
     if [ "$check" ]; then
       increment_secure "RDS instance $db is encrypted"
     else
       increment_insecure "RDS instance $db is not encrypted"
     fi
     # Check if KMS is being used
-    key_id=`aws rds describe-db-instances --region $aws_region --db-instance-identifier $db --query 'DBInstances[].KmsKeyId' --output text |cut -f2 -d/`
+    key_id=$( aws rds describe-db-instances --region $aws_region --db-instance-identifier $db --query 'DBInstances[].KmsKeyId' --output text | cut -f2 -d/ )
     if [ "$key_id" ]; then
       increment_secure "RDS instance $db is encrypted with a KMS key"
     else
       increment_insecure "RDS instance $db is not encrypted with a KMS key"
     fi
     # Check if RDS instance is publicly accessible
-    check=`aws rds describe-db-instances --region $aws_region --db-instance-identifier $db --query 'DBInstances[].PubliclyAccessible' |grep true`
+    check=$( aws rds describe-db-instances --region $aws_region --db-instance-identifier $db --query 'DBInstances[].PubliclyAccessible' | grep true )
     if [ ! "$check" ]; then
       increment_secure "RDS instance $db is not publicly accessible"
     else
       increment_insecure "RDS instance $db is publicly accessible"
     fi
     # Check if RDS instance VPC is publicly accessible
-    sgs=`aws rds describe-db-instances --region $aws_region --db-instance-identifier $db --query 'DBInstances[*].VpcSecurityGroups[].VpcSecurityGroupId' --output text`
+    sgs=$( aws rds describe-db-instances --region $aws_region --db-instance-identifier $db --query 'DBInstances[*].VpcSecurityGroups[].VpcSecurityGroupId' --output text )
     for sg in $sgs; do
       check_aws_open_port $sg 3306 tcp MySQL RDS $db
     done
     # Check RDS instance is not on a public subnet
-    subnets=`aws rds describe-db-instances --region $aws_region --db-instance-identifier $db --query 'DBInstances[].DBSubnetGroup.Subnets[].SubnetIdentifier' --output text`
+    subnets=$( aws rds describe-db-instances --region $aws_region --db-instance-identifier $db --query 'DBInstances[].DBSubnetGroup.Subnets[].SubnetIdentifier' --output text )
     for subnet in $subnets; do
-      check=`aws ec2 describe-route-tables --region $aws_region --filters "Name=association.subnet-id,Values=$subnet" --query 'RouteTables[].Routes[].DestinationCidrBlock' |grep "0.0.0.0/0"`
+      check=$( aws ec2 describe-route-tables --region $aws_region --filters "Name=association.subnet-id,Values=$subnet" --query 'RouteTables[].Routes[].DestinationCidrBlock' | grep "0.0.0.0/0" )
       if [ ! "$check" ]; then
         increment_secure "RDS instance $db is not on a public facing subnet"
       else
@@ -70,7 +70,7 @@ audit_aws_rds () {
       fi
     done
     # Check that your Amazon RDS production databases are not using 'awsuser' as master 
-    check=`aws rds describe-db-instances --region $aws_region --db-instance-identifier $db --query 'DBInstances[].MasterUsername' |grep "awsuser"`
+    check=$( aws rds describe-db-instances --region $aws_region --db-instance-identifier $db --query 'DBInstances[].MasterUsername' | grep "awsuser" )
     if [ ! "$check" ]; then
       increment_secure "RDS instance $db is not using awsuser as master username"
     else

--- a/modules/audit_aws_rec_dynamodb.sh
+++ b/modules/audit_aws_rec_dynamodb.sh
@@ -6,13 +6,13 @@
 audit_aws_rec_dynamodb () {
   # Check for zero length tables
   verbose_message "DynamoDB"
-  tables=`aws dynamodb list-tables --region $aws_region --query 'TableNames' --output text`
+  tables=$( aws dynamodb list-tables --region $aws_region --query 'TableNames' --output text )
   for table in $tables; do
-    size=`aws dynamodb describe-table --region $aws_region --table-name $table --query 'Table.ItemCount' --output text`
+    size=$( aws dynamodb describe-table --region $aws_region --table-name $table --query 'Table.ItemCount' --output text )
     if [ ! "$size" -eq 0 ]; then
       increment_secure "DynamoDB table $table is not empty"
     else
-      increment_insecure "DynameDB table $table is empty"
+      increment_insecure "DynamoDB table $table is empty"
     fi
   done
 }

--- a/modules/audit_aws_rec_ec.sh
+++ b/modules/audit_aws_rec_ec.sh
@@ -6,19 +6,19 @@
 audit_aws_rec_ec () {
   verbose_message "ElastiCache Recommendation"
   # Ensure that your AWS ElastiCache Reserved Instances (RIs) are renewed before expiration
-  caches=`aws elasticache describe-reserved-cache-nodes --region $aws_region --query 'ReservedCacheNodes[].ReservedCacheNodeId' --output text`
+  caches=$( aws elasticache describe-reserved-cache-nodes --region $aws_region --query 'ReservedCacheNodes[].ReservedCacheNodeId' --output text )
   for cache in $caches; do
-    start_date=`aws elasticache describe-reserved-cache-nodes --region $aws_region --reserved-cache-node-id $cache --query 'ReservedDBInstances[].ReservedCacheNodes' --output text |cut -f1 -d.`
-    dur_secs=`aws elasticache describe-reserved-cache-nodes --region $aws_region --reserved-cache-node-id $cache --query 'ReservedDBInstances[].Duration' --output text`
-    curr_secs=`date "+%s"`
+    start_date=$( aws elasticache describe-reserved-cache-nodes --region $aws_region --reserved-cache-node-id $cache --query 'ReservedDBInstances[].ReservedCacheNodes' --output text | cut -f1 -d. )
+    dur_secs=$( aws elasticache describe-reserved-cache-nodes --region $aws_region --reserved-cache-node-id $cache --query 'ReservedDBInstances[].Duration' --output text )
+    curr_secs=$( date "+%s" )
     if [ "$os_name" = "Linux" ]; then
-      start_secs=`date -d "$start_date" "+%s"`
+      start_secs=$( date -d "$start_date" "+%s" )
     else
-      start_secs=`date -j -f "%Y-%m-%dT%H:%M:%SS" "$start_date" "+%s"`
+      start_secs=$( date -j -f "%Y-%m-%dT%H:%M:%SS" "$start_date" "+%s" )
     fi
-    exp_secs=`echo "($start_secs + $dur_secs)" |bc`
-    test_secs=`echo "(7 * 84600)" |bc`
-    left_secs=`echo "($exp_sec - $curr_secs)" |bc`
+    exp_secs=$( echo "($start_secs + $dur_secs)" | bc )
+    test_secs=$( echo "(7 * 84600)" |bc )
+    left_secs=$( echo "($exp_sec - $curr_secs)" | bc )
     if [ "$left_secs" -lt "$test_secs" ]; then
       increment_secure "Reserved ElastiCache instance $cache has more than 7 days remaining"
     else
@@ -26,4 +26,3 @@ audit_aws_rec_ec () {
     fi
   done
 }
-

--- a/modules/audit_aws_rec_ec2.sh
+++ b/modules/audit_aws_rec_ec2.sh
@@ -14,11 +14,11 @@
 
 audit_aws_rec_ec2 () {
   verbose_message "EC2 Recommendations"
-  volumes=`aws ec2 describe-volumes --region $aws_region --query 'Volumes[].VolumeId' --output text`
+  volumes=$( aws ec2 describe-volumes --region $aws_region --query 'Volumes[].VolumeId' --output text )
   for volume in $volumes; do
     if [ "${check_volattach}" = "y" ]; then
       # Check for EC2 volumes that are unattached
-      check=`aws ec2 describe-volumes --region $aws_region --volume-id $volume --query 'Volumes[].State' --output text`
+      check=$( aws ec2 describe-volumes --region $aws_region --volume-id $volume --query 'Volumes[].State' --output text )
       if [ ! "$check" = "available" ]; then
         increment_secure "EC2 volume $volume is attached to an instance"
       else
@@ -27,7 +27,7 @@ audit_aws_rec_ec2 () {
     fi
     if [ "${check_volattach}" = "y" ]; then
       # Check that EC2 volumes are using cost effective storage
-      check=`aws ec2 describe-volumes --region $aws_region --volume-id $volume --query 'Volumes[].VolumeType' |grep "gp2"`
+      check=$( aws ec2 describe-volumes --region $aws_region --volume-id $volume --query 'Volumes[].VolumeType' | grep "gp2" )
       if [ "$check" ]; then
         increment_secure "EC2 volume $volume is using General Purpose SSD"
       else
@@ -37,18 +37,18 @@ audit_aws_rec_ec2 () {
   done
   # Check date of snapshots
   if [ "${check_snapage}" = "y" ]; then
-    arn=`aws iam get-user --query "User.Arn" --output text |cut -f5 -d:`
-    snapshots=`aws ec2 describe-snapshots --region $aws_region --owner-ids $arn --filters Name=status,Values=completed --query "Snapshots[].SnapshotId" --output text`
+    arn=$( aws iam get-user --query "User.Arn" --output text | cut -f5 -d: )
+    snapshots=$( aws ec2 describe-snapshots --region $aws_region --owner-ids $arn --filters Name=status,Values=completed --query "Snapshots[].SnapshotId" --output text )
     counter=0
     for snapshot in $snapshots; do
-      snap_date=`aws ec2 describe-snapshots --region $aws_region --snapshot-id $snapshot --query "Snapshots[].StartTime" --output text --output text |cut -f1 -d.`
+      snap_date=$( aws ec2 describe-snapshots --region $aws_region --snapshot-id $snapshot --query "Snapshots[].StartTime" --output text --output text | cut -f1 -d. )
       if [ "$os_name" = "Linux" ]; then
-        snap_secs=`date -d "$snap_date" "+%s"`
+        snap_secs=$( date -d "$snap_date" "+%s" )
       else
-        snap_secs=`date -j -f "%Y-%m-%dT%H:%M:%S" "$snap_date" "+%s"`
+        snap_secs=$( date -j -f "%Y-%m-%dT%H:%M:%S" "$snap_date" "+%s" )
       fi
-      curr_secs=`date "+%s"`
-      diff_days=`echo "($curr_secs - $snap_secs)/84600" |bc`
+      curr_secs=$( date "+%s" )
+      diff_days=$( echo "($curr_secs - $snap_secs)/84600" | bc )
       if [ "$diff_days" -gt "$aws_ec2_max_retention" ]; then
         increment_insecure "EC2 snapshot $snapshot is more than $aws_ec2_max_retention days old"
       else
@@ -65,10 +65,10 @@ audit_aws_rec_ec2 () {
     fi
   fi
   # Check Security Groups have Name tags
-  sgs=`aws ec2 describe-security-groups --region $aws_region --query 'SecurityGroups[].GroupId' --output text`
+  sgs=$( aws ec2 describe-security-groups --region $aws_region --query 'SecurityGroups[].GroupId' --output text )
   for sg in $sgs; do
     if [ ! "$sg" = "default" ]; then
-      name=`aws ec2 describe-security-groups --region $aws_region --group-id $sg --query "SecurityGroups[].Tags[?Key==\\\`Name\\\`].Value" 2> /dev/null --output text`
+      name=$( aws ec2 describe-security-groups --region $aws_region --group-id $sg --query "SecurityGroups[].Tags[?Key==\\\`Name\\\`].Value" 2> /dev/null --output text )
       if [ ! "$name" ]; then
         increment_insecure "AWS Security Group $sg does not have a Name tag"
         verbose_message "" fix
@@ -76,7 +76,7 @@ audit_aws_rec_ec2 () {
         verbose_message "" fix
       else
         if [ "${strict_valid_names}" = "y" ]; then
-          check=`echo ${name} |grep "^sg-$valid_tag_string"`
+          check=$( echo ${name} |grep "^sg-$valid_tag_string" )
           if [ "$check" ]; then
             increment_secure "AWS Security Group $sg has a valid Name tag"
           else
@@ -87,9 +87,9 @@ audit_aws_rec_ec2 () {
     fi
   done
   # Check Volumes have Name tags
-  volumes=`aws ec2 describe-volumes --region $aws_region --query "Volumes[].VolumeId" --output text`
+  volumes=$( aws ec2 describe-volumes --region $aws_region --query "Volumes[].VolumeId" --output text )
   for volume in $volumes; do
-    name=`aws ec2 describe-volumes --region $aws_region --volume-id $volume --query "Volumes[].Tags[?Key==\\\`Name\\\`].Value" --output text`
+    name=$( aws ec2 describe-volumes --region $aws_region --volume-id $volume --query "Volumes[].Tags[?Key==\\\`Name\\\`].Value" --output text )
     if [ ! "$name" ]; then
       increment_insecure "AWS EC2 volume $volume does not have a Name tag"
       verbose_message "" fix
@@ -97,9 +97,9 @@ audit_aws_rec_ec2 () {
       verbose_message "" fix
     else
       if [ "${strict_valid_names}" = "y" ]; then
-        check=`echo $name |grep "^ami-$valid_tag_string"`
+        check=$( echo $name |grep "^ami-$valid_tag_string" )
         if [ "$check" ]; then
-          increment_secure "AWS EC2 volume $olume has a valid Name tag"
+          increment_secure "AWS EC2 volume $volume has a valid Name tag"
         else
           increment_insecure "AWS EC2 volume $volume does not have a valid Name tag"
         fi
@@ -107,9 +107,9 @@ audit_aws_rec_ec2 () {
     fi
   done
   # Check AMIs have Name tags
-  images=`aws ec2 describe-images --region $aws_region --owners self --query "Images[].ImageId" --output text`
+  images=$( aws ec2 describe-images --region $aws_region --owners self --query "Images[].ImageId" --output text )
   for image in $images; do
-	  name=`aws ec2 describe-images --region $aws_region --owners self --image-id $image --query "Images[].Tags[?Key==\\\`Name\\\`].Value" --output text`
+	  name=$( aws ec2 describe-images --region $aws_region --owners self --image-id $image --query "Images[].Tags[?Key==\\\`Name\\\`].Value" --output text )
     if [ ! "$name" ]; then
       increment_insecure "AWS AMI $image does not have a Name tag"
       verbose_message "" fix
@@ -117,7 +117,7 @@ audit_aws_rec_ec2 () {
       verbose_message "" fix
     else
       if [ "${strict_valid_names}" = "y" ]; then
-        check=`echo $name |grep "^ami-$valid_tag_string"`
+        check=$( echo $name |grep "^ami-$valid_tag_string" )
         if [ "$check" ]; then
           increment_secure "AWS AMI $image has a valid Name tag"
         else
@@ -127,10 +127,10 @@ audit_aws_rec_ec2 () {
     fi
   done
   # Check Instances have Name tags
-  instances=`aws ec2 describe-instances --region $aws_region --query "Reservations[].Instances[].InstanceId" --output text`
+  instances=$( aws ec2 describe-instances --region $aws_region --query "Reservations[].Instances[].InstanceId" --output text )
   for instance in $instances; do
     for tag in Name Role Environment Owner; do
-      check=`aws ec2 describe-instances --region $aws_region --instance-id $instance --query "Reservations[].Instances[].Tags[?Key==\\\`$tag\\\`].Value" --output text`
+      check=$( aws ec2 describe-instances --region $aws_region --instance-id $instance --query "Reservations[].Instances[].Tags[?Key==\\\`$tag\\\`].Value" --output text )
       if [ ! "$check" ]; then
         increment_insecure "AWS Instance $instance does not have a $tag tag"
         verbose_message "" fix
@@ -138,7 +138,7 @@ audit_aws_rec_ec2 () {
         verbose_message "" fix
       else
         if [ "${strict_valid_names}" = "y" ]; then
-          check=`echo $name |grep "^ec2-$valid_tag_string"`
+          check=$( echo $name |grep "^ec2-$valid_tag_string" )
           if [ "$check" ]; then
             increment_secure "AWS Instance $instance has a valid $tag tag"
           else
@@ -147,8 +147,8 @@ audit_aws_rec_ec2 () {
         fi
       fi
     done
-    term_check=`aws ec2 describe-instance-attribute --region $aws_region --instance-id $instance --attribute disableApiTermination --query "DisableApiTermination" |grep -i true`
-    asg_check=`aws autoscaling describe-auto-scaling-instances --region $aws_region --query 'AutoScalingInstances[].InstanceId' |grep $instance`
+    term_check=$( aws ec2 describe-instance-attribute --region $aws_region --instance-id $instance --attribute disableApiTermination --query "DisableApiTermination" | grep -i true )
+    asg_check=$( aws autoscaling describe-auto-scaling-instances --region $aws_region --query 'AutoScalingInstances[].InstanceId' | grep $instance )
     if [ "$term_check" ] && [ ! "$asg_check" ]; then
       increment_secure "Termination Protection is enabled for instance $instance"
     else
@@ -156,9 +156,9 @@ audit_aws_rec_ec2 () {
     fi
   done
   # Check Instances are from self produced images
-  images=`aws ec2 describe-instances --region $aws_region --query 'Reservations[].Instances[].ImageId' --output text`
+  images=$( aws ec2 describe-instances --region $aws_region --query 'Reservations[].Instances[].ImageId' --output text )
   for image in $images; do
-    owner=`aws ec2 describe-images --region $aws_region --image-ids $image --query 'Images[].ImageOwnerAlias' --output text`
+    owner=$( aws ec2 describe-images --region $aws_region --image-ids $image --query 'Images[].ImageOwnerAlias' --output text )
     if [ "$owner" = "self" ] || [ ! "$owner" ]; then
       increment_secure "AWS AMI $image is a self produced image"
     else
@@ -167,17 +167,17 @@ audit_aws_rec_ec2 () {
     fi
   done
   # Check number of Elastic IPs that are being used
-  max_ips=`aws ec2 describe-account-attributes --region $aws_region --attribute-names max-elastic-ips --query "AccountAttributes[].AttributeValues[].AttributeValue" --output text`
-  no_ips=`aws ec2 describe-addresses --region $aws_region --query 'Addresses[].PublicIp' --filters "Name=domain,Values=standard" --output text |wc -l`
+  max_ips=$( aws ec2 describe-account-attributes --region $aws_region --attribute-names max-elastic-ips --query "AccountAttributes[].AttributeValues[].AttributeValue" --output text )
+  no_ips=$( aws ec2 describe-addresses --region $aws_region --query 'Addresses[].PublicIp' --filters "Name=domain,Values=standard" --output text | wc -l )
   if [ "$max_ips" -ne  "$no_ips" ]; then
     increment_secure "Number of Elastic IPs consumed is less than limit of $max_ips"
   else
     increment_insecure "Number of Elastic IPs consumed has reached limit of $max_ips"
   fi
   # Check Instances are using EC2-VPC and not EC2-Classic
-  instances=`aws ec2 describe-instances --region $aws_region --query 'Reservations[*].Instances[*].InstanceId' --output text`
+  instances=$( aws ec2 describe-instances --region $aws_region --query 'Reservations[*].Instances[*].InstanceId' --output text )
   for instance in $instances; do
-    vpc_id=`aws ec2 describe-instances --region $aws_region --instance-ids $instance --query 'Reservations[*].Instances[*].VpcId' --output text`
+    vpc_id=$( aws ec2 describe-instances --region $aws_region --instance-ids $instance --query 'Reservations[*].Instances[*].VpcId' --output text )
     if [ "$vpc_id" ]; then
       increment_secure "Instance $instance is an EC2-VPC platform"
     else

--- a/modules/audit_aws_rec_elb.sh
+++ b/modules/audit_aws_rec_elb.sh
@@ -8,9 +8,9 @@
 
 audit_aws_rec_elb () {
   verbose_message "ELB Recommendations"
-	elbs=`aws elb describe-load-balancers --region $aws_region --query "LoadBalancerDescriptions[].LoadBalancerName" --output text`
+	elbs=$( aws elb describe-load-balancers --region $aws_region --query "LoadBalancerDescriptions[].LoadBalancerName" --output text )
   for elb in $elbs; do
-    check=`aws elb describe-load-balancer-attributes --region $aws_region --load-balancer-name $elb  --query "LoadBalancerAttributes.ConnectionDraining" |grep Enabled |grep true`
+    check=$( aws elb describe-load-balancer-attributes --region $aws_region --load-balancer-name $elb --query "LoadBalancerAttributes.ConnectionDraining" | grep Enabled | grep true )
     if [ ! "$check" ]; then
       increment_insecure "ELB $elb does not have connection draining enabled"
       verbose_message "" fix
@@ -19,19 +19,19 @@ audit_aws_rec_elb () {
     else
       increment_secure "ELB $elb has connection draining"
     fi
-    check=`aws elb describe-load-balancer-attributes --region $aws_region --load-balancer-name $elb  --query "LoadBalancerAttributes.CrossZoneLoadBalancing" |grep Enabled |grep true`
+    check=$( aws elb describe-load-balancer-attributes --region $aws_region --load-balancer-name $elb  --query "LoadBalancerAttributes.CrossZoneLoadBalancing" | grep Enabled | grep true )
     if [ ! "$check" ]; then
       increment_insecure "ELB $elb does not have cross zone balancing enabled"
     else
       increment_secure "ELB $elb has cross zone balancing enabled"
     fi
-    number=`aws elb describe-instance-health --region $aws_region --load-balancer-name $elb  --query "InstanceStates[].State" |grep InService |wc -l`
+    number=$( aws elb describe-instance-health --region $aws_region --load-balancer-name $elb  --query "InstanceStates[].State" | grep InService | wc -l )
     if [ "$number" -lt 2 ]; then
       increment_insecure "ELB $elb does not have at least 2 instances in service"
     else
       increment_secure "ELB $elb has at least two instances in service"
     fi
-    instances=`aws elb describe-instance-health --region $aws_region --load-balancer-name $elb  --query "InstanceStates[].InstanceState" --filter Name=state,Values='OutOfService' --output text`
+    instances=$( aws elb describe-instance-health --region $aws_region --load-balancer-name $elb  --query "InstanceStates[].InstanceState" --filter Name=state,Values='OutOfService' --output text )
     for instance in $instances; do
       increment_insecure "ELB $elb instance $instance is out of service "
     done

--- a/modules/audit_aws_rec_es.sh
+++ b/modules/audit_aws_rec_es.sh
@@ -6,28 +6,28 @@
 
 audit_aws_rec_es () {
   verbose_message "Elasticsearch Recommendations"
-  domains=`aws es list-domain-names --region $aws_region --query "DomainNames[].DomainName" --output text`
+  domains=$( aws es list-domain-names --region $aws_region --query "DomainNames[].DomainName" --output text )
   for domain in $domains; do
     # Check that ES domains have dedicated masters
-    check=`aws es describe-elasticsearch-domain --domain-name $domain --query "DomainStatus.ElasticsearchClusterConfig.DedicatedMasterEnabled" |grep true`
+    check=$( aws es describe-elasticsearch-domain --domain-name $domain --query "DomainStatus.ElasticsearchClusterConfig.DedicatedMasterEnabled" | grep true )
     if [ "$check" ]; then
       increment_secure "Elasticsearch doamin $domain has dedicated master nodes"
     else
       increment_insecure "Elasticsearch domain $domain does not have dedicated master nodes"
     fi
     # Check that ES domains are using cost effective storage
-    check=`aws es describe-elasticsearch-domain --domain-name $domain --query 'DomainStatus.EBSOptions.VolumeType' |grep "gp2"`
+    check=$( aws es describe-elasticsearch-domain --domain-name $domain --query 'DomainStatus.EBSOptions.VolumeType' | grep "gp2" )
     if [ "$check" ]; then
       increment_secure "Elasticsearch doamin $domain is using General Purpose SSD"
     else
       increment_insecure "Elasticsearch domain $domain is not using General Purpose SSD"
-      vol_size=`aws es describe-elasticsearch-domain --domain-name $domain --query 'DomainStatus.EBSOptions.VolumeSize' --output text`
+      vol_size=$( aws es describe-elasticsearch-domain --domain-name $domain --query 'DomainStatus.EBSOptions.VolumeSize' --output text )
       verbose_message "" fix
       verbose_message "aws es update-elasticsearch-domain-config --region $aws_region --domain-name $domain --ebs-options EBSEnabled=true,VolumeType=\"gp2\",VolumeSize=$vol_size" fix
       verbose_message "" fix
     fi
     # Check that ES domains have cross zone awareness
-    check=`aws es describe-elasticsearch-domain --domain-name $domain --query "DomainStatus.ElasticsearchClusterConfig.ZoneAwarenessEnabled" |grep true`
+    check=$( aws es describe-elasticsearch-domain --domain-name $domain --query "DomainStatus.ElasticsearchClusterConfig.ZoneAwarenessEnabled" | grep true )
     if [ "$check" ]; then
       increment_secure "Elasticsearch doamin $domain has cross zone awareness"
     else

--- a/modules/audit_aws_rec_inspector.sh
+++ b/modules/audit_aws_rec_inspector.sh
@@ -6,31 +6,31 @@
 audit_aws_rec_inspector () {
   verbose_message "Inspector Recommendations"
   # check for templates
-  templates=`aws inspector list-assessment-templates 2> /dev/null --output text`
+  templates=$( aws inspector list-assessment-templates 2> /dev/null --output text )
   if [ "$templates" ]; then
     # Check for CVEs in assessments
-    assessments=`aws inspector list-assessment-runs --region $aws_region --output text`
+    assessments=$( aws inspector list-assessment-runs --region $aws_region --output text )
     if [ "$assessments" ]; then
-      token=`aws inspector list-findings --query nextToken --output text |grep -v None`
-      findings=`aws inspector list-findings --query findingArns --output text |grep -v None`
+      token=$( aws inspector list-findings --query nextToken --output text | grep -v None )
+      findings=$( aws inspector list-findings --query findingArns --output text | grep -v None )
       for finding in $findings; do
-        instance=`aws inspector describe-findings --finding-arns $finding --query findings[].attributes[?key==\\\`INSTANCE_ID\\\`].value --output text`
-        cve_id=`aws inspector describe-findings --finding-arns $finding --query findings[].attributes[?key==\\\`CVE_ID\\\`].value --output text`
+        instance=$( aws inspector describe-findings --finding-arns $finding --query findings[].attributes[?key==\\\`INSTANCE_ID\\\`].value --output text )
+        cve_id=$( aws inspector describe-findings --finding-arns $finding --query findings[].attributes[?key==\\\`CVE_ID\\\`].value --output text )
         if [ "$cve_id" ]; then
           increment_insecure "Instance $instance is vulnerable to $cve_id"
         fi
       done
       if [ "$token" ]; then
         while [ "$token" ] ; do
-          findings=`aws inspector list-findings --next-token $token --query findingArns --output text |grep -v None`
+          findings=$( aws inspector list-findings --next-token $token --query findingArns --output text |grep -v None )
           for finding in $findings; do
-            instance=`aws inspector describe-findings --finding-arns $finding --query findings[].attributes[?key==\\\`INSTANCE_ID\\\`].value --output text`
-            cve_id=`aws inspector describe-findings --finding-arns $finding --query findings[].attributes[?key==\\\`CVE_ID\\\`].value --output text`
+            instance=$( aws inspector describe-findings --finding-arns $finding --query findings[].attributes[?key==\\\`INSTANCE_ID\\\`].value --output text )
+            cve_id=$( aws inspector describe-findings --finding-arns $finding --query findings[].attributes[?key==\\\`CVE_ID\\\`].value --output text )
             if [ "$cve_id" ]; then
               increment_insecure "Instance $instance is vulnerable to $cve_id"
             fi
           done
-          token=`aws inspector list-findings --next-token $token --query nextToken --output text |grep -v None`
+          token=$( aws inspector list-findings --next-token $token --query nextToken --output text |grep -v None )
         done
       fi
     fi

--- a/modules/audit_aws_rec_monitoring.sh
+++ b/modules/audit_aws_rec_monitoring.sh
@@ -5,11 +5,11 @@
 
 audit_aws_rec_monitoring () {
   verbose_message "CloudWatch Recommendations"
-  trails=`aws cloudtrail describe-trails --region $aws_region --query "trailList[].CloudWatchLogsLogGroupArn" --output text |awk -F':' '{print $7}'`
+  trails=$( aws cloudtrail describe-trails --region $aws_region --query "trailList[].CloudWatchLogsLogGroupArn" --output text |awk -F':' '{print $7}' )
   if [ "$trails" ]; then
     increment_secure "CloudWatch log groups exits for CloudTrail"
     for trail in $trails; do
-      metrics=`aws logs describe-metric-filters --region $aws_region --log-group-name $trail --query "metricFilters[].filterPattern" --output text`
+      metrics=$( aws logs describe-metric-filters --region $aws_region --log-group-name $trail --query "metricFilters[].filterPattern" --output text )
       if [ ! "$metrics" ]; then
         increment_insecure "CloudWatch log group $trail has no metrics"
         verbose_message "" fix
@@ -21,7 +21,7 @@ audit_aws_rec_monitoring () {
         verbose_message "" fix
       else
         for metric in RunInstances instanceType ; do
-          check=`aws logs describe-metric-filters --region $aws_region --log-group-name $trail --query "metricFilters[].filterPattern" --output text |grep "$metric"`
+          check=$( aws logs describe-metric-filters --region $aws_region --log-group-name $trail --query "metricFilters[].filterPattern" --output text | grep "$metric" )
           if [ "$check" ]; then
             increment_secure "CloudWatch log group $trail metrics include $metric"
           else

--- a/modules/audit_aws_rec_rds.sh
+++ b/modules/audit_aws_rec_rds.sh
@@ -8,10 +8,10 @@
 
 audit_aws_rec_rds () {
   verbose_message "RDS Recommendations"
-  dbs=`aws rds describe-db-instances --region $aws_region --query 'DBInstances[].DBInstanceIdentifier' --output text`
+  dbs=$( aws rds describe-db-instances --region $aws_region --query 'DBInstances[].DBInstanceIdentifier' --output text )
   for db in $dbs; do
     # Check if database is Multi-AZ
-    check=`aws rds describe-db-instances --region $aws_region --db-instance-identifier $db --query 'DBInstances[].MultiAZ' |grep true`
+    check=$( aws rds describe-db-instances --region $aws_region --db-instance-identifier $db --query 'DBInstances[].MultiAZ' | grep true )
     if [ "$check" ]; then
       increment_secure "RDS instance $db is Multi-AZ enabled"
     else
@@ -21,14 +21,14 @@ audit_aws_rec_rds () {
       verbose_message "" fix
     fi
     # Check that EC2 volumes are using cost effective storage
-    check=`aws rds describe-db-instances --region $aws_region --db-instance-identifier $db --query 'DBInstances[].StorageType' |grep "gp2"`
+    check=$( aws rds describe-db-instances --region $aws_region --db-instance-identifier $db --query 'DBInstances[].StorageType' |grep "gp2" )
     if [ "$check" = "available" ]; then
       increment_secure "RDS instance $db is using General Purpose SSD"
     else
       increment_insecure "RDS instance $db is not using General Purpose SSD"
     fi
     # Check backup retention period is at least 7 days
-    check=`aws rds describe-db-instances --region $aws_region --db-instance-identifier $db --query 'DBInstances[].BackupRetentionPeriod' --output text`
+    check=$( aws rds describe-db-instances --region $aws_region --db-instance-identifier $db --query 'DBInstances[].BackupRetentionPeriod' --output text )
     if [ ! "$check" -lt "$aws_rds_min_retention" ]; then
       increment_secure "RDS instance $db has a retention period greater than $aws_rds_min_retention"
     else
@@ -36,19 +36,19 @@ audit_aws_rec_rds () {
     fi
   done
   # Ensure that your AWS RDS Reserved Instances (RIs) are renewed before expiration
-  dbs=`aws rds describe-reserved-db-instances --region $aws_region --query 'ReservedDBInstances[].ReservedDBInstanceId' --output text`
+  dbs=$( aws rds describe-reserved-db-instances --region $aws_region --query 'ReservedDBInstances[].ReservedDBInstanceId' --output text )
   for db in $dbs; do
-    start_date=`aws rds describe-reserved-db-instances --region $aws_region --reserved-db-instance-id $db --query 'ReservedDBInstances[].StartTime' --output text |cut -f1 -d.`
-    dur_secs=`aws rds describe-reserved-db-instances --region $aws_region --reserved-db-instance-id $db --query 'ReservedDBInstances[].Duration' --output text`
-    curr_secs=`date "+%s"`
+    start_date=$( aws rds describe-reserved-db-instances --region $aws_region --reserved-db-instance-id $db --query 'ReservedDBInstances[].StartTime' --output text |cut -f1 -d. )
+    dur_secs=$( aws rds describe-reserved-db-instances --region $aws_region --reserved-db-instance-id $db --query 'ReservedDBInstances[].Duration' --output text )
+    curr_secs=$( date "+%s" )
     if [ "$os_name" = "Linux" ]; then
-      start_secs=`date -d "$start_date" "+%s"`
+      start_secs=$( date -d "$start_date" "+%s" )
     else
-      start_secs=`date -j -f "%Y-%m-%dT%H:%M:%SS" "$start_date" "+%s"`
+      start_secs=$( date -j -f "%Y-%m-%dT%H:%M:%SS" "$start_date" "+%s" )
     fi
-    exp_secs=`echo "($start_secs + $dur_secs)" |bc`
-    test_secs=`echo "(7 * 84600)" |bc`
-    left_secs=`echo "($exp_sec - $curr_secs)" |bc`
+    exp_secs=$( echo "($start_secs + $dur_secs)" | bc )
+    test_secs=$( echo "(7 * 84600)" | bc )
+    left_secs=$( echo "($exp_secs - $curr_secs)" | bc )
     if [ "$left_secs" -lt "$test_secs" ]; then
       increment_secure "Reserved RDS instance $db has more than 7 days remaining"
     else

--- a/modules/audit_aws_rec_redshift.sh
+++ b/modules/audit_aws_rec_redshift.sh
@@ -5,19 +5,19 @@
 
 audit_aws_rec_redshift () {
   verbose_message "Redshift Recommendations"
-  dbs=`aws redshift describe-reserved-nodes --region $aws_region --query 'ReservedNodes[].ReservedNodeId' --output text`
+  dbs=$( aws redshift describe-reserved-nodes --region $aws_region --query 'ReservedNodes[].ReservedNodeId' --output text )
   for db in $dbs; do
-    start_date=`aws redshift describe-reserved-nodes --region $aws_region --reserved-node-id $db --query 'ReservedNodes[].StartTime' --output text |cut -f1 -d.`
-    dur_secs=`aws redshift describe-reserved-nodes --region $aws_region --reserved-node-id $db --query 'ReservedNodes[].Duration' --output text`
-    curr_secs=`date "+%s"`
+    start_date=$( aws redshift describe-reserved-nodes --region $aws_region --reserved-node-id $db --query 'ReservedNodes[].StartTime' --output text | cut -f1 -d. )
+    dur_secs=$( aws redshift describe-reserved-nodes --region $aws_region --reserved-node-id $db --query 'ReservedNodes[].Duration' --output text )
+    curr_secs=$( date "+%s" )
     if [ "$os_name" = "Linux" ]; then
-      start_secs=`date -d "$start_date" "+%s"`
+      start_secs=$( date -d "$start_date" "+%s" )
     else
-      start_secs=`date -j -f "%Y-%m-%dT%H:%M:%SS" "$start_date" "+%s"`
+      start_secs=$( date -j -f "%Y-%m-%dT%H:%M:%SS" "$start_date" "+%s" )
     fi
-    exp_secs=`echo "($start_secs + $dur_secs)" |bc`
-    test_secs=`echo "(7 * 84600)" |bc`
-    left_secs=`echo "($exp_sec - $curr_secs)" |bc`
+    exp_secs=$( echo "($start_secs + $dur_secs)" | bc )
+    test_secs=$( echo "(7 * 84600)" | bc )
+    left_secs=$( echo "($exp_secs - $curr_secs)" | bc )
     if [ "$left_secs" -lt "$test_secs" ]; then
       increment_secure "Reserved Redshift instance $db has more than 7 days remaining"
     else

--- a/modules/audit_aws_rec_vpcs.sh
+++ b/modules/audit_aws_rec_vpcs.sh
@@ -7,10 +7,10 @@
 audit_aws_rec_vpcs () {
   verbose_message "VPC Recommendations"
   # Check Security Groups have Name tags
-  vpcs=`aws ec2 describe-vpcs --region $aws_region --query 'Vpcs[].VpcId' --output text`
+  vpcs=$( aws ec2 describe-vpcs --region $aws_region --query 'Vpcs[].VpcId' --output text )
   for vpc in $vpcs; do
     if [ ! "$vpc" = "default" ]; then
-      name=`aws ec2 describe-vpcs --region $aws_region --vpc-ids $vpcs --query "Vpcs[].Tags[?Key==\\\`Name\\\`].Value" 2> /dev/null --output text`
+      name=$( aws ec2 describe-vpcs --region $aws_region --vpc-ids $vpcs --query "Vpcs[].Tags[?Key==\\\`Name\\\`].Value" 2> /dev/null --output text )
       if [ ! "$name" ]; then
         increment_insecure "AWS VPC $vpc does not have a Name tag"
         verbose_message "" fix
@@ -18,7 +18,7 @@ audit_aws_rec_vpcs () {
         verbose_message "" fix
       else
         if [ "${strict_valid_names}" = "y" ]; then
-          check=`echo $name |grep "^vpc-$valid_tag_string"`
+          check=$( echo $name |grep "^vpc-$valid_tag_string" )
           if [ "$check" ]; then
             increment_secure "AWS VPC $vpc has a valid Name tag"
           else
@@ -29,9 +29,9 @@ audit_aws_rec_vpcs () {
     fi
   done
   # Check VPN tunnel redundancy 
-  tunnels=`aws ec2 describe-vpn-connections --region $aws_region --query "VpnConnections[].VpnConnectionId" --output text`
+  tunnels=$( aws ec2 describe-vpn-connections --region $aws_region --query "VpnConnections[].VpnConnectionId" --output text )
   for tunnel in $tunnels; do
-    check=`aws ec2 describe-vpn-connections --region $aws_region --vpc-connection-ids $tunnel --query "VpnConnections[].VgwTelemetry[].Status" |grep "DOWN"`
+    check=$( aws ec2 describe-vpn-connections --region $aws_region --vpc-connection-ids $tunnel --query "VpnConnections[].VgwTelemetry[].Status" |grep "DOWN" )
     if [ "$check" ]; then
       increment_insecure "AWS VPC $vpc does not have VPN tunnel redundancy"
     else

--- a/modules/audit_aws_redshift.sh
+++ b/modules/audit_aws_redshift.sh
@@ -11,10 +11,10 @@
 
 audit_aws_redshift () {
   verbose_message "Redshift"
-  dbs=`aws redshift describe-clusters --region $aws_region --query 'Clusters[].ClusterIdentifier' --output text`
+  dbs=$( aws redshift describe-clusters --region $aws_region --query 'Clusters[].ClusterIdentifier' --output text )
   for db in $dbs; do
     # Check if version upgrades are enabled
-    check=`aws redshift describe-clusters --region $aws_region --cluster-identifier $db --query 'Clusters[].AllowVersionUpgrade' |grep true`
+    check=$( aws redshift describe-clusters --region $aws_region --cluster-identifier $db --query 'Clusters[].AllowVersionUpgrade' | grep true )
     if [ "$check" ]; then
       increment_secure "Redshift instance $db has version upgrades enabled"
     else
@@ -24,7 +24,7 @@ audit_aws_redshift () {
       verbose_message "" fix
     fi
     # Check if audit logging is enabled
-    check=`aws redshift describe-logging-status --region $aws_region --cluster-identifier $db |grep true`
+    check=$( aws redshift describe-logging-status --region $aws_region --cluster-identifier $db | grep true )
     if [ "$check" ]; then
       increment_secure "Redshift instance $db has logging enabled"
     else
@@ -34,30 +34,30 @@ audit_aws_redshift () {
       verbose_message "" fix
     fi
     # Check if encryption is enabled
-    check=`aws redshift describe-logging-status --region $aws_region --cluster-identifier $db --query 'Clusters[].Encrypted' |grep true`
+    check=$( aws redshift describe-logging-status --region $aws_region --cluster-identifier $db --query 'Clusters[].Encrypted' | grep true )
     if [ "$check" ]; then
       increment_secure "Redshift instance $db has encryption enabled"
     else
       increment_insecure "Redshift instance $db does not have encryption enabled"
     fi
     # Check if KMS keys are being used
-    check=`aws redshift describe-logging-status --region $aws_region --cluster-identifier $db --query 'Clusters[].[Encrypted,KmsKeyId]' |grep true`
+    check=$( aws redshift describe-logging-status --region $aws_region --cluster-identifier $db --query 'Clusters[].[Encrypted,KmsKeyId]' | grep true )
     if [ "$check" ]; then
       increment_secure "Redshift instance $db is using KMS keys"
     else
       increment_insecure "Redshift instance $db is not using KMS keys"
     fi
     # Check if EC2-VPC platform is being used rather than EC2-Classic
-    check=`aws redshift describe-logging-status --region $aws_region --cluster-identifier $db --query 'Clusters[].VpcId' --output text`
+    check=$( aws redshift describe-logging-status --region $aws_region --cluster-identifier $db --query 'Clusters[].VpcId' --output text )
     if [ "$check" ]; then
       increment_secure "Redshift instance $db is using the EC2-VPC platform"
     else
       increment_insecure "Redshift instance $db may be using the EC2-Classic platform"
     fi
     # Check that parameter groups require SSL
-    groups=`aws redshift describe-logging-status --region $aws_region --cluster-identifier $db --query 'Clusters[].ClusterParameterGroups[].ParameterGroupName[]' --output text`
+    groups=$( aws redshift describe-logging-status --region $aws_region --cluster-identifier $db --query 'Clusters[].ClusterParameterGroups[].ParameterGroupName[]' --output text )
     for group in $groups; do
-      check=`aws redshift describe-cluster-parameters --region $aws_region --parameter-group-name $group --query 'Parameters[].Description' |grep -i ssl`
+      check=$( aws redshift describe-cluster-parameters --region $aws_region --parameter-group-name $group --query 'Parameters[].Description' | grep -i ssl )
       if [ "$check" ]; then
         increment_secure "Redshift instance $db parameter group $group is using SSL"
       else
@@ -65,7 +65,7 @@ audit_aws_redshift () {
       fi
     done
     # Check if Redshift is publicly available
-    check=`aws redshift describe-clusters --region $aws_region --cluster-identifier $db --query 'Clusters[].PubliclyAccessible' |grep true`
+    check=$( aws redshift describe-clusters --region $aws_region --cluster-identifier $db --query 'Clusters[].PubliclyAccessible' | grep true )
     if [ ! "$check" ]; then
       increment_secure "Redshift instance $db is not publicly available"
     else

--- a/modules/audit_aws_s3.sh
+++ b/modules/audit_aws_s3.sh
@@ -7,17 +7,17 @@
 
 audit_aws_s3 () {
   verbose_message "S3"
-  buckets=`aws s3api list-buckets --region $aws_region --query 'Buckets[*].Name' --output text`
+  buckets=$( aws s3api list-buckets --region $aws_region --query 'Buckets[*].Name' --output text )
   for bucket in $buckets; do
     for user in http://acs.amazonaws.com/groups/global/AllUsers http://acs.amazonaws.com/groups/global/AuthenticatedUsers; do
-      grants=`aws s3api get-bucket-acl --region $aws_region --bucket $bucket |grep URI |grep "$user"`
+      grants=$( aws s3api get-bucket-acl --region $aws_region --bucket $bucket | grep URI | grep "$user" )
       if [ "$grants" ]; then
         increment_insecure "Bucket $bucket grants access to Principal $user"
       else
         increment_secure "Bucket $bucket does not grant access to Principal $user"
       fi
     done
-    logging=`aws s3api get-bucket-logging --region $aws_region --bucket $bucket`
+    logging=$( aws s3api get-bucket-logging --region $aws_region --bucket $bucket )
     if [ ! "$logging" ]; then
       increment_insecure "Bucket $bucket does not have access logging enabled"
       verbose_message "" fix
@@ -27,7 +27,7 @@ audit_aws_s3 () {
     else
       increment_secure "Bucket $bucket has access logging enabled"
     fi
-    check=`aws s3api get-bucket-versioning --bucket $bucket |grep Enabled`
+    check=$( aws s3api get-bucket-versioning --bucket $bucket | grep Enabled )
     if [ "$check" ]; then
       increment_secure "Bucket $bucket has versioning enabled"
     else

--- a/modules/audit_aws_ses.sh
+++ b/modules/audit_aws_ses.sh
@@ -6,9 +6,9 @@
 audit_aws_ses () {
   verbose_message "SES"
   # determine if your AWS Simple Email Service (SES) identities (domains and email addresses) are configured to use DKIM signatures
-  domains=`aws ses list-identities --region $aws_region --query Identities --output text 2> /dev/null`
+  domains=$( aws ses list-identities --region $aws_region --query Identities --output text 2> /dev/null )
   for domain in $domains; do
-    check=`aws ses get-identity-dkim-attributes --region $aws_region --identities $domain |grep DkimEnabled |grep true`
+    check=$( aws ses get-identity-dkim-attributes --region $aws_region --identities $domain | grep DkimEnabled | grep true )
     if [ "$check" ]; then
       increment_secure "Domain $domain has DKIM enabled" 
     else

--- a/modules/audit_aws_sgs.sh
+++ b/modules/audit_aws_sgs.sh
@@ -16,9 +16,9 @@
 
 audit_aws_sgs () {
   verbose_message "Security Groups"
-  sgs=`aws ec2 describe-security-groups --region $aws_region --query SecurityGroups[].GroupId --output text`
+  sgs=$( aws ec2 describe-security-groups --region $aws_region --query SecurityGroups[].GroupId --output text )
   for sg in $sgs; do
-    inbound=`aws ec2 describe-security-groups --region $aws_region --group-ids $sg --filters Name=group-name,Values='default' --query 'SecurityGroups[*].{IpPermissions:IpPermissions,GroupId:GroupId}' |grep "0.0.0.0/0"`
+    inbound=$( aws ec2 describe-security-groups --region $aws_region --group-ids $sg --filters Name=group-name,Values='default' --query 'SecurityGroups[*].{IpPermissions:IpPermissions,GroupId:GroupId}' | grep "0.0.0.0/0" )
     if [ ! "$inbound" ]; then
       increment_secure "Security Group $sg does not have a open inbound rule"
     else
@@ -40,7 +40,7 @@ audit_aws_sgs () {
       check_aws_open_port $sg 5432 tcp PostgreSQL none none
       check_aws_open_port $sg 27017 tcp MongoDB none none
     fi
-    outbound=`aws ec2 describe-security-groups --region $aws_region --group-ids $sg --filters Name=group-name,Values='default' --query 'SecurityGroups[*].{IpPermissionsEgress:IpPermissionsEgress,GroupId:GroupId}' |grep "0.0.0.0/0"`
+    outbound=$( aws ec2 describe-security-groups --region $aws_region --group-ids $sg --filters Name=group-name,Values='default' --query 'SecurityGroups[*].{IpPermissionsEgress:IpPermissionsEgress,GroupId:GroupId}' | grep "0.0.0.0/0" )
     if [ ! "$outbound" ]; then
       increment_secure "Security Group $sg does not have a open outbound rule"
     else

--- a/modules/audit_aws_sns.sh
+++ b/modules/audit_aws_sns.sh
@@ -6,17 +6,17 @@
 
 audit_aws_sns () {
   verbose_message "SNS"
-  topics=`aws sns list-topics --region $aws_region --query 'Topics[].TopicArn' --output text`
+  topics=$( aws sns list-topics --region $aws_region --query 'Topics[].TopicArn' --output text )
   for topic in $topics; do
     # Check SNS topics have subscribers
-    subscribers=`aws sns list-subscriptions-by-topic --region $aws_region --topic-arn $topic --output text`
+    subscribers=$( aws sns list-subscriptions-by-topic --region $aws_region --topic-arn $topic --output text )
     if [ ! "$subscribers" ]; then
       increment_insecure "SNS topic $topic has no subscribers"
     else
       increment_secure "SNS topic has subscribers, review subscribers"
     fi
     #check SNS topics are not publicly accessible
-    check=`aws sns get-topic-attributes --region $aws_region --topic-arn $topic --query 'Attributes.Policy'  |egrep "\*|{\"AWS\":\"\*\"}"`
+    check=$( aws sns get-topic-attributes --region $aws_region --topic-arn $topic --query 'Attributes.Policy'  |egrep "\*|{\"AWS\":\"\*\"}" )
     if [ "$check" ]; then
       increment_insecure "SNS topic $topic is publicly accessible"
     else

--- a/modules/audit_aws_support_role.sh
+++ b/modules/audit_aws_support_role.sh
@@ -5,10 +5,10 @@
 
 audit_aws_support_role () {
   verbose_message "Support"
-  arn=`aws iam list-policies --query "Policies[?PolicyName == 'AWSSupportAccess']" |grep Arn | awk -F': ' '{print $2}' |sed "s/ //g" |sed "s/,//g" |sed "s/\"//g"`
-  roles=`aws iam list-entities-for-policy --policy-arn "$arn" |grep PolicyRoles |cut -f2 -d:`
-  users=`aws iam list-entities-for-policy --policy-arn "$arn" |grep PolicyGroups |cut -f2 -d:`
-  groups=`aws iam list-entities-for-policy --policy-arn "$arn" |grep PolicyUsers |cut -f2 -d:`
+  arn=$( aws iam list-policies --query "Policies[?PolicyName == 'AWSSupportAccess']" |grep Arn | awk -F': ' '{print $2}' |sed "s/ //g" |sed "s/,//g" |sed "s/\"//g" )
+  roles=$( aws iam list-entities-for-policy --policy-arn "$arn" |grep PolicyRoles |cut -f2 -d: )
+  users=$( aws iam list-entities-for-policy --policy-arn "$arn" |grep PolicyGroups |cut -f2 -d: )
+  groups=$( aws iam list-entities-for-policy --policy-arn "$arn" |grep PolicyUsers |cut -f2 -d: )
   if [ ! $roles ] && [ ! $users ] && [ ! $groups ]; then
     increment_secure "A support role has been created to manage incidents"
   else


### PR DESCRIPTION
Remove use of legacy backticks for command substitutions per http://mywiki.wooledge.org/BashFAQ/082
Other minor typo/fixes