### PR TITLE
Fix awk error, remove superfluous wc -l and fix bug in path modules/audit_system_auth_nullok.sh

### DIFF
--- a/functions/check_chkconfig_service.sh
+++ b/functions/check_chkconfig_service.sh
@@ -57,10 +57,10 @@ check_chkconfig_service () {
     fi
     log_file="chkconfig.log"
     if [ "$service_level" = "3" ]; then
-      actual_status=$( $chk_config --list $service_name 2> /dev/null | awk '{print \$5}' | cut -f2 -d':' | awk '{print \$1}' )
+      actual_status=$( $chk_config --list $service_name 2> /dev/null | awk '{print $5}' | cut -f2 -d':' | awk '{print $1}' )
     fi
     if [ "$service_level" = "5" ]; then
-      actual_status=$( $chk_config --list $service_name 2> /dev/null | awk '{print \$7}' | cut -f2 -d':' | awk '{print \$1}' )
+      actual_status=$( $chk_config --list $service_name 2> /dev/null | awk '{print $7}' | cut -f2 -d':' | awk '{print $1}' )
     fi
     if [ "$audit_mode" = 2 ]; then
       restore_file="$restore_dir/$log_file"

--- a/functions/check_initd_service.sh
+++ b/functions/check_initd_service.sh
@@ -12,7 +12,7 @@ check_initd_service () {
     service_name=$1
     correct_status=$2
     log_file="initd.log"
-    service_check=$( ls /etc/init.d | grep "^$service_name$" | wc -l | sed 's/ //g' )
+    service_check=$( ls /etc/init.d | grep -c "^$service_name$" | sed 's/ //g' )
     if [ "$service_check" != 0 ]; then
       if [ "$correct_status" = "disabled" ]; then
         check_file="/etc/init.d/_$service_name"

--- a/functions/replace_file_value.sh
+++ b/functions/replace_file_value.sh
@@ -38,7 +38,7 @@ replace_file_value () {
     verbose_message "$string"
   fi
   if [ -f "$check_file" ]; then
-    check_dfs=$( cat $check_file |grep "$new_check_value" |wc -l |sed "s/ //g" )
+    check_dfs=$( cat $check_file | grep -c "$new_check_value" | sed "s/ //g" )
   fi
   if [ "$check_dfs" != 0 ]; then
     if [ "$audit_mode" != 2 ]; then

--- a/modules/audit_aws_keys.sh
+++ b/modules/audit_aws_keys.sh
@@ -39,7 +39,7 @@ audit_aws_keys () {
   # Check for SSH keys
   users=$( aws iam list-users --query 'Users[].UserName' --output text )
   for user in $users; do
-    check=$( aws iam list-ssh-public-keys --region $aws_region --user-name $user | grep Active | wc -l )
+    check=$( aws iam list-ssh-public-keys --region $aws_region --user-name $user | grep -c Active )
     if [ "$check" -gt 1 ]; then
       increment_insecure "User $user does has more than one active SSH key"
     else

--- a/modules/audit_aws_mfa.sh
+++ b/modules/audit_aws_mfa.sh
@@ -36,7 +36,7 @@ audit_aws_mfa () {
   mfa_check=$( aws iam get-account-summary | grep "AccountMFAEnabled" | cut -f1 -d: | sed "s/ //g" | sed "s/,//g" )
   if [ "$mfa_check" = "1" ]; then
     increment_secure "The root account has MFA enabled"
-    mfa_check=$( iaws iam list-virtual-mfa-devices | grep "SerialNumber" | grep "root_account" | wc -l )
+    mfa_check=$( iaws iam list-virtual-mfa-devices | grep "SerialNumber" | grep -c "root_account" )
     if [ "$mfa_check" = "0" ]; then
       increment_secure "The root account does not have a virtual MFA"
     else

--- a/modules/audit_aws_rec_elb.sh
+++ b/modules/audit_aws_rec_elb.sh
@@ -25,7 +25,7 @@ audit_aws_rec_elb () {
     else
       increment_secure "ELB $elb has cross zone balancing enabled"
     fi
-    number=$( aws elb describe-instance-health --region $aws_region --load-balancer-name $elb  --query "InstanceStates[].State" | grep InService | wc -l )
+    number=$( aws elb describe-instance-health --region $aws_region --load-balancer-name $elb  --query "InstanceStates[].State" | grep -c InService )
     if [ "$number" -lt 2 ]; then
       increment_insecure "ELB $elb does not have at least 2 instances in service"
     else

--- a/modules/audit_bonjour_advertising.sh
+++ b/modules/audit_bonjour_advertising.sh
@@ -13,7 +13,7 @@ audit_bonjour_advertising() {
     if [ "$audit_mode" = 2 ]; then
       restore_file $check_file $restore_dir
     else
-      multicast_test=$( grep 'NoMulticastAdvertisements' $check_file | wc -l )
+      multicast_test=$( grep -c 'NoMulticastAdvertisements' $check_file )
       if [ "$ansible" = 1 ]; then
         echo ""
         echo "- name: Checking $string"

--- a/modules/audit_cd_sharing.sh
+++ b/modules/audit_cd_sharing.sh
@@ -8,7 +8,7 @@ audit_cd_sharing() {
   if [ "$os_name" = "Darwin" ]; then
     verbose_message "DVD/CD Sharing"
     if [ "$audit_mode" != 2 ]; then
-      share_test=$( launchctl list | awk '{print $3}' | grep ODSAgent | wc -l )
+      share_test=$( launchctl list | awk '{print $3}' | grep -c ODSAgent )
       if [ "$share_test" = "1" ]; then
         increment_insecure "DVD/CD sharing is enabled"
         verbose_message "" fix

--- a/modules/audit_ftp_logging.sh
+++ b/modules/audit_ftp_logging.sh
@@ -9,7 +9,7 @@ audit_ftp_logging () {
     if [ "$os_name" = "SunOS" ]; then
       if [ "$os_version" = "10" ]; then
         get_command="svcprop -p inetd_start/exec svc:/network/ftp:default"
-        check_value=$( $get_command | grep "\-d" | wc -l )
+        check_value=$( $get_command | grep -c "\-d" )
         file_header="ftpd_logging"
         if [ "$audit_mode" != 2 ]; then
          verbose_message "File $file_header"

--- a/modules/audit_groups_exist.sh
+++ b/modules/audit_groups_exist.sh
@@ -18,7 +18,7 @@ audit_groups_exist () {
     group_fail=0
     if [ "$audit_mode" != 2 ]; then
       for group_id in $( getent passwd | cut -f4 -d ":" ); do
-        group_exists=$( grep -v "^#" $check_file | cut -f3 -d":" | grep "^$group_id$" | wc -l | sed "s/ //g" )
+        group_exists=$( grep -v "^#" $check_file | cut -f3 -d":" | grep -c "^$group_id$" | sed "s/ //g" )
         if [ "$group_exists" = 0 ]; then
           group_fail=1
           if [ "$audit_mode" = 1 ];then

--- a/modules/audit_issue_banner.sh
+++ b/modules/audit_issue_banner.sh
@@ -23,7 +23,7 @@ audit_issue_banner () {
       check_file_perms $check_file 0644 root root
       issue_check=0
       if [ -f "$check_file" ]; then
-        issue_check=$( grep 'NOTICE TO USERS' $check_file | wc -l )
+        issue_check=$( grep -c 'NOTICE TO USERS' $check_file )
       fi
       if [ "$audit_mode" != 2 ]; then
        verbose_message "Security message in $check_file"

--- a/modules/audit_system_auth_nullok.sh
+++ b/modules/audit_system_auth_nullok.sh
@@ -6,7 +6,7 @@
 audit_system_auth_nullok () {
   if [ "$os_name" = "Linux" ]; then
     if [ "$audit_mode" != 2 ]; then
-      for check_file in etc/pam.d/common-auth /etc/pam.d/system-auth; do
+      for check_file in /etc/pam.d/common-auth /etc/pam.d/system-auth; do
         if [ -f "$check_file" ]; then
           verbose_message "For nullok entry in $check_file"
           check_value=0


### PR DESCRIPTION
Various fixes.

Performance should improve by not having to spawn wc -l when grepping anyway. grep -c can do the work.

AIX has grep -c
https://www.ibm.com/support/knowledgecenter/ssw_aix_72/g_commands/grep.html#grep__row-d3e143928

Solaris has grep -c
https://docs.oracle.com/cd/E88353_01/html/E37839/grep-1.html#scrolltoc

Linux has grep -c
https://man7.org/linux/man-pages/man1/grep.1.html

Darwin/MacOS has grep -c
https://opensource.apple.com/source/grep/grep-28/grep/doc/grep.1.auto.html